### PR TITLE
Fix bug where each segment of a load pattern had

### DIFF
--- a/lib/config/src/lib.rs
+++ b/lib/config/src/lib.rs
@@ -142,7 +142,6 @@ impl LinearBuilder {
 
     pub fn append(&mut self, start_percent: f64, end_percent: f64, duration: Duration) {
         self.duration += duration;
-        let duration = duration.as_nanos() as f64;
         let lb = LinearBuilderPiece::new(start_percent, end_percent, duration);
         self.pieces.push(lb);
     }
@@ -156,11 +155,11 @@ impl LinearBuilder {
 pub struct LinearBuilderPiece {
     pub start_percent: f64,
     pub end_percent: f64,
-    pub duration: f64,
+    pub duration: Duration,
 }
 
 impl LinearBuilderPiece {
-    fn new(start_percent: f64, end_percent: f64, duration: f64) -> Self {
+    fn new(start_percent: f64, end_percent: f64, duration: Duration) -> Self {
         LinearBuilderPiece {
             start_percent,
             end_percent,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -835,7 +835,7 @@ fn create_load_test_future(
                             PerX::second(piece.end_percent * *s as f64),
                         ),
                     };
-                    mod_interval2.append_segment(start, duration, end);
+                    mod_interval2.append_segment(start, piece.duration, end);
                 }
                 mod_interval = Some(Box::pin(mod_interval2.into_stream(run_config.start_at)));
             }

--- a/tests/.gitattributes
+++ b/tests/.gitattributes
@@ -1,0 +1,1 @@
+*.out text eol=lf

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -47,7 +47,6 @@ fn int1() {
 
         // let stdout = stdout2.get_string();
         let stderr = stderr2.get_string();
-        dbg!(&stderr);
         assert!(
             did_succeed2.load(Ordering::Relaxed),
             "test run failed. {}",


### PR DESCRIPTION
its duration set to the duration of the test instead of for that segment