### PR TITLE
Tweak how we determine the limit for parallel

### DIFF
--- a/lib/channel/src/lib.rs
+++ b/lib/channel/src/lib.rs
@@ -92,7 +92,12 @@ impl ChannelClosed {
     }
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl<T> Sender<T> {
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
     pub fn limit(&self) -> Limit {
         self.limit.clone()
     }


### PR DESCRIPTION
requests per endpoint and auto-
sized providers grow.

Previously the number of max parallel requests was determined based on
the maximum length of any `send: block` providers that endpoint provides
for, or the `max_parallel_requests` parameter, whichever is smaller.
Now, we instead take into consideration the maximum number of empty
slots in any `send:block` providers multiplied by a multiplier between
1 and 10. If any of the `send:block` providers are empty the multiplier
is incremented. If all of the providers are full the multiplier is
decremented.

For auto-sized providers, previously they would grow (the limit would
increment) whenever the provider is filled and then emptied and anytime
an endpoint determines it should be firing off a request but it was
waiting for a value from the provider. This commit removes the latter
behavior.