### PR TITLE
Fix regression in earlier 0.5.8 preview builds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -627,6 +627,7 @@ fn create_try_run_future(
     stdout: FCSender<MsgType>,
     stderr: FCSender<MsgType>,
 ) -> Result<impl Future<Output = ()>, TestError> {
+    // create a logger for the try run
     let select = if let TryRunFormat::Human = try_config.format {
         r#""`\
          Request\n\
@@ -673,6 +674,7 @@ fn create_try_run_future(
         &try_config.config_file,
     )?;
 
+    // setup "filters" which decide which endpoints are included in this try run
     let filters: Vec<_> = try_config
         .filters
         .unwrap_or_default()
@@ -717,6 +719,7 @@ fn create_try_run_future(
 
     let mut endpoints = Endpoints::new();
 
+    // create the endpoints
     for mut endpoint in config.endpoints.into_iter() {
         let required_providers = mem::take(&mut endpoint.required_providers);
 
@@ -755,6 +758,7 @@ fn create_try_run_future(
 
     let client = create_http_client(config_config.client.keepalive)?;
 
+    // create the stats channel
     let (stats_tx, stats_rx) = create_try_run_stats_channel(test_ended_tx.subscribe(), stderr);
     tokio::spawn(stats_rx);
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -253,7 +253,7 @@ impl Builder {
                     set.insert(tx.clone());
                 }
                 if on_demand {
-                    let stream = provider.on_demand.clone().into_stream();
+                    let stream = provider.on_demand.clone();
                     on_demand_streams.push(Box::new(stream));
                 }
                 Outgoing::new(v, ProviderOrLogger::Provider(tx))

--- a/tests/int_on_demand.yaml
+++ b/tests/int_on_demand.yaml
@@ -1,0 +1,30 @@
+providers:
+  a:
+    response: {}
+
+load_pattern:
+  - linear:
+      from: 100%
+      to: 100%
+      over: 5s
+
+loggers:
+  test:
+    to: stderr
+
+vars:
+  port: "${PORT}"
+
+
+endpoints:
+  - url: http://localhost:${port}
+    peak_load: 1hps
+    provides:
+      a:
+        select: 1
+    on_demand: true
+    
+  - url: http://localhost:${port}?${a}
+    logs:
+      test:
+        select: 1


### PR DESCRIPTION
which broke `on_demand`, and was manifest most often by try runs hanging
Add integration test for on_demand