### PR TITLE
Fix release ci

### DIFF
--- a/.github/workflows/release-test-server.yml
+++ b/.github/workflows/release-test-server.yml
@@ -17,12 +17,12 @@ jobs:
         run: |
           set -x
           version=${GITHUB_REF/refs\/tags\//}
-          echo ::set-env name=VERSION::$version
+          echo VERSION=$version >> $GITHUB_ENV
           # check if this is a "preview" release and should be marked as "prerelease" in GitHub releases
           if [[ $version == *"preview"* ]]; then
-            echo ::set-env name=PRERELEASE::true
+            echo PRERELEASE=true >> $GITHUB_ENV
           else
-            echo ::set-env name=PRERELEASE::false
+            echo PRERELEASE=false >> $GITHUB_ENV
           fi
         shell: bash
 
@@ -69,9 +69,9 @@ jobs:
         shell: bash
         run: |
           release_upload_url="$(cat artifacts/release-upload-url)"
-          echo "::set-env name=RELEASE_UPLOAD_URL::$release_upload_url"
+          echo "RELEASE_UPLOAD_URL=$release_upload_url" >> $GITHUB_ENV
           release_version="$(cat artifacts/release-version)"
-          echo "::set-env name=VERSION::$release_version"
+          echo "VERSION=$release_version" >> $GITHUB_ENV
 
       - name: Build
         uses: actions-rs/toolchain@v1
@@ -88,7 +88,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           asset_name="test-server-$VERSION-linux-x86_64.tar.xz"
-          echo "::set-env name=ASSET_NAME::$asset_name"
+          echo "ASSET_NAME=$asset_name" >> $GITHUB_ENV
           XZ_OPT=-9 tar -C ./target/release/ -cJf $asset_name test-server
 
       - name: Compress for Windows
@@ -96,14 +96,14 @@ jobs:
         shell: bash
         run: |
           asset_name="test-server-$VERSION-windows-x86_64.zip"
-          echo "::set-env name=ASSET_NAME::$asset_name"
+          echo "ASSET_NAME=$asset_name" >> $GITHUB_ENV
           7z a -mm=Deflate64 -mfb=258 -mpass=15 $asset_name ./target/release/test-server.exe
 
       - name: Compress for macOS
         if: matrix.os == 'macos-latest'
         run: |
           asset_name="test-server-$VERSION-apple-darwin-x86_64.tar.xz"
-          echo "::set-env name=ASSET_NAME::$asset_name"
+          echo "ASSET_NAME=$asset_name" >> $GITHUB_ENV
           XZ_OPT=-9 tar -C ./target/release/ -cJf $asset_name test-server
 
       - name: Upload release asset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,16 +17,16 @@ jobs:
         run: |
           set -x
           version=${GITHUB_REF/refs\/tags\//}
-          echo ::set-env name=VERSION::$version
+          echo VERSION=$version >> $GITHUB_ENV
           # remove the leading "v" for subsequent usage
           version=${version/v/}
           # check if this is a "preview" release and should be marked as "prerelease" in GitHub releases
           if [[ $version == *"preview"* ]]; then
-            echo ::set-env name=PRERELEASE::true
+            echo PRERELEASE=true >> $GITHUB_ENV
           else
             # check that the version in Cargo.toml is equal to the tag
             grep -q "version = \"${version}\"" Cargo.toml || (echo "$(tput setaf 1)Tag version did NOT match version in Cargo.toml" && false)
-            echo ::set-env name=PRERELEASE::false
+            echo PRERELEASE=false >> $GITHUB_ENV
           fi
         shell: bash
 
@@ -73,9 +73,9 @@ jobs:
         shell: bash
         run: |
           release_upload_url="$(cat artifacts/release-upload-url)"
-          echo "::set-env name=RELEASE_UPLOAD_URL::$release_upload_url"
+          echo "RELEASE_UPLOAD_URL=$release_upload_url" >> $GITHUB_ENV
           release_version="$(cat artifacts/release-version)"
-          echo "::set-env name=VERSION::$release_version"
+          echo "VERSION=$release_version" >> $GITHUB_ENV
 
       - name: Set Cargo.toml version
         id: set_cargo_version
@@ -110,7 +110,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           asset_name="pewpew-$VERSION-linux-x86_64-musl.tar.xz"
-          echo "::set-env name=ASSET_NAME::$asset_name"
+          echo "ASSET_NAME=$asset_name" >> $GITHUB_ENV
           XZ_OPT=-9 tar -C ./target/x86_64-unknown-linux-musl/release/ -cJf $asset_name pewpew
 
       - name: Compress for Windows
@@ -118,14 +118,14 @@ jobs:
         shell: bash
         run: |
           asset_name="pewpew-$VERSION-windows-x86_64.zip"
-          echo "::set-env name=ASSET_NAME::$asset_name"
+          echo "ASSET_NAME=$asset_name" >> $GITHUB_ENV
           7z a -mm=Deflate64 -mfb=258 -mpass=15 $asset_name ./target/release/pewpew.exe
 
       - name: Compress for macOS
         if: matrix.os == 'macos-latest'
         run: |
           asset_name="pewpew-$VERSION-apple-darwin-x86_64.tar.xz"
-          echo "::set-env name=ASSET_NAME::$asset_name"
+          echo "ASSET_NAME=$asset_name" >> $GITHUB_ENV
           XZ_OPT=-9 tar -C ./target/release/ -cJf $asset_name pewpew
 
       - name: Upload release asset

--- a/lib/channel/src/hash_set.rs
+++ b/lib/channel/src/hash_set.rs
@@ -8,6 +8,9 @@ use std::{
     io::{Error as IOError, Write},
 };
 
+// a hasher that takes the bytes that are written to it and returns
+// them as the hash. This is used because our custom HashSet will
+// only have hashes stored within
 #[derive(Default)]
 struct PassThroughHasher(u64);
 
@@ -23,6 +26,8 @@ impl Hasher for PassThroughHasher {
     }
 }
 
+// builder for the `PassThroughHasher`. Necessary because DashSet requires
+// a `BuildHasher`
 #[derive(Default, Clone, Copy)]
 struct PassThroughHasherBuilder;
 
@@ -54,11 +59,15 @@ impl HashSet {
         }
     }
 
+    // insert a value into the hash set returning a boolean
+    // indicating whether the value was inserted into the set
+    // (it was not already in there)
     pub fn insert<H: Serialize>(&self, h: &H) -> bool {
         let hash = self.get_hash(h);
         self.inner.insert(hash)
     }
 
+    // removes a value from the hash set
     pub fn remove<H: Serialize>(&self, h: &H) {
         let hash = self.get_hash(h);
         self.inner.remove(&hash);
@@ -76,7 +85,8 @@ impl HashSet {
     }
 }
 
-// a helper struct to implment `Write` on top of a `Hasher`
+// a helper struct to implment `Write` on top of a `Hasher`, we use `Write` to bridge the
+// gap between `Serialize` and `Hash`
 struct HashHelper<H: Hasher>(H);
 
 impl<H: Hasher> Write for HashHelper<H> {

--- a/lib/config_wasm/src/lib.rs
+++ b/lib/config_wasm/src/lib.rs
@@ -7,6 +7,7 @@ pub struct Config(LoadTest);
 
 #[wasm_bindgen]
 impl Config {
+    // build a config object from raw bytes (in javascript this is passing in a Uint8Array)
     #[wasm_bindgen(constructor)]
     pub fn from_bytes(bytes: &[u8], env_vars: Map) -> Result<Config, JsValue> {
         let env_vars = serde_wasm_bindgen::from_value(env_vars.into())?;
@@ -15,11 +16,13 @@ impl Config {
         Ok(Config(load_test))
     }
 
+    // return the duration of the test in seconds
     #[wasm_bindgen(js_name = getDuration)]
     pub fn get_duration(&self) -> u64 {
         self.0.get_duration().as_secs()
     }
 
+    // return a string array of logger files
     #[wasm_bindgen(js_name = getLoggerFiles)]
     pub fn get_logger_files(&self) -> Box<[JsValue]> {
         self.0
@@ -30,11 +33,13 @@ impl Config {
             .into_boxed_slice()
     }
 
+    // return the bucket size for the test
     #[wasm_bindgen(js_name = getBucketSize)]
     pub fn get_bucket_size(&self) -> u64 {
         self.0.config.general.bucket_size.as_secs()
     }
 
+    // return a string array of files used to feed providers
     #[wasm_bindgen(js_name = getInputFiles)]
     pub fn get_input_files(&self) -> Box<[JsValue]> {
         self.0
@@ -51,6 +56,7 @@ impl Config {
             .into_boxed_slice()
     }
 
+    // returns nothing if the config file has no errors, throws an error containing a string description, if the config file has errors
     #[wasm_bindgen(js_name = checkOk)]
     pub fn check_ok(&self) -> Result<(), JsValue> {
         self.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -919,8 +919,8 @@ fn get_providers_from_config(
             config::Provider::File(mut template) => {
                 // the auto_buffer_start_size is not the default
                 if auto_size != default_buffer_size {
-                    if let config::Limit::AutoSized(_) = &template.buffer {
-                        template.buffer = config::Limit::AutoSized(auto_size);
+                    if let config::Limit::Dynamic(_) = &template.buffer {
+                        template.buffer = config::Limit::Dynamic(auto_size);
                     }
                 }
                 util::tweak_path(&mut template.path, config_path);
@@ -930,14 +930,14 @@ fn get_providers_from_config(
             config::Provider::Response(mut template) => {
                 // the auto_buffer_start_size is not the default
                 if auto_size != default_buffer_size {
-                    if let config::Limit::AutoSized(_) = &template.buffer {
-                        template.buffer = config::Limit::AutoSized(auto_size);
+                    if let config::Limit::Dynamic(_) = &template.buffer {
+                        template.buffer = config::Limit::Dynamic(auto_size);
                     }
                 }
                 response_providers.insert(name.clone());
                 providers::response(template)
             }
-            config::Provider::List(values) => providers::literals(values.clone()),
+            config::Provider::List(values) => providers::list(values.clone()),
         };
         providers.insert(name.clone(), provider);
     }

--- a/src/request/body_handler.rs
+++ b/src/request/body_handler.rs
@@ -209,7 +209,7 @@ mod tests {
     use config::{EndpointProvidesSendOptions::*, Select};
 
     fn create_outgoing(select: Select) -> (Outgoing, Receiver<json::Value>) {
-        let (tx, rx) = channel::channel(Limit::Hard(1), false);
+        let (tx, rx) = channel::channel(Limit::Static(1), false);
         (Outgoing::new(select, ProviderOrLogger::Provider(tx)), rx)
     }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -457,7 +457,7 @@ impl Stats {
                 format!(
                     "\n- {}:\n  length: {}\n  limit: {}\n  \
                      number of receivers: {}\n  number of senders: {}\n",
-                    Paint::yellow(stats.provider).dimmed(),
+                    Paint::yellow(stats.name).dimmed(),
                     stats.len,
                     stats.limit,
                     stats.receiver_count,

--- a/src/util.rs
+++ b/src/util.rs
@@ -20,8 +20,8 @@ pub fn tweak_path(rest: &mut String, base: &PathBuf) {
 
 pub fn config_limit_to_channel_limit(limit: config::Limit) -> channel::Limit {
     match limit {
-        config::Limit::AutoSized(n) => channel::Limit::auto(n),
-        config::Limit::Hard(n) => channel::Limit::hard(n),
+        config::Limit::Dynamic(n) => channel::Limit::dynamic(n),
+        config::Limit::Static(n) => channel::Limit::statik(n),
     }
 }
 


### PR DESCRIPTION
I tested this out already by creating a `v0.0.0-test-release-ci-preview` tag and it looks like GitHub was able to go through the release CI without any problems. I will leave that release/tag up until you've verified then I will remove it.

One thing to note: I noticed when I pushed that tag to GitHub, I accidentally also pushed the `v0.5.8-preview3` tag. It seems that when you pushed out the tag, @tkmcmaster, my local repo fetched it, but then when you deleted it my local repo never did. I manually deleted it locally and re-deleted it on GitHub. 

[This](https://stackoverflow.com/questions/10491146/in-git-how-do-i-sync-my-tags-against-a-remote-server/49215190) seems relevant. By default VS Code does automatic `git fetch`es in the background which pulls down all the remote tags. We may want to make sure our environment is setup to do `git fetch --prune --prune-tags`.

With all of that said, we should be more careful in pushing out tags and instead of doing `git push --tags` which pushes out **all** local tags, do `git push origin <tag>` to only push a single one.