### PR TITLE
Fix config wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,7 @@ name = "config-wasm"
 version = "0.0.0"
 dependencies = [
  "config",
+ "getrandom",
  "js-sys",
  "serde",
  "serde-wasm-bindgen",
@@ -639,8 +640,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/guide/serve-guide.sh
+++ b/guide/serve-guide.sh
@@ -17,6 +17,7 @@ trap_ctrlc ()
  
 # initialise trap to call trap_ctrlc function
 # when signal 2 (SIGINT) is received
+# https://unix.stackexchange.com/questions/314554/why-do-i-get-an-error-message-when-trying-to-trap-a-sigint-signal
 trap "trap_ctrlc" INT
 
 PROJECT_ROOT=$(realpath ../)

--- a/guide/serve-guide.sh
+++ b/guide/serve-guide.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
+### To build, first install wasm-pack, then run this script
+# cargo install wasm-pack --version 0.8.1
+# cargo install mdbook
 set -e
 set -x
 
 # this function is called when Ctrl-C is sent
-function trap_ctrlc ()
+trap_ctrlc ()
 {
     # cleanup
     rm -rf book
@@ -14,7 +17,7 @@ function trap_ctrlc ()
  
 # initialise trap to call trap_ctrlc function
 # when signal 2 (SIGINT) is received
-trap "trap_ctrlc" SIGINT
+trap "trap_ctrlc" INT
 
 PROJECT_ROOT=$(realpath ../)
 GUIDE_DIR=$(realpath $PROJECT_ROOT/guide)

--- a/lib/config_wasm/Cargo.toml
+++ b/lib/config_wasm/Cargo.toml
@@ -14,4 +14,7 @@ js-sys = "0.3"
 serde = "1"
 serde-wasm-bindgen = "0.1"
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"]  }
+# Not a direct dependency but get random as of 0.2.2 throws an error on "unsupported targets"
+# https://docs.rs/getrandom/0.2.2/getrandom/#unsupported-targets
+# The fix is to add it as a supported target and specify the target. As of 0.2.2 both browser and nodejs use "js"
 getrandom = { version = "0.2", features = ["js"] }

--- a/lib/config_wasm/Cargo.toml
+++ b/lib/config_wasm/Cargo.toml
@@ -14,3 +14,4 @@ js-sys = "0.3"
 serde = "1"
 serde-wasm-bindgen = "0.1"
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"]  }
+getrandom = { version = "0.2", features = ["js"] }

--- a/lib/config_wasm/build-node.sh
+++ b/lib/config_wasm/build-node.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+### To build, first install wasm-pack, then run this script
+# cargo install wasm-pack --version 0.8.1
 set -e
 set -x
 


### PR DESCRIPTION
- Fixed the config wasm build per the getrandom docs for javascript
- Fixed issues with running on WSL2 Ubuntu 20.04 which doesn't support SIGINT only INT

