### PR TITLE
On demand issue46

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.9"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
 dependencies = [
  "bytes 0.5.6",
  "futures-channel",

--- a/lib/config/src/expression_functions.rs
+++ b/lib/config/src/expression_functions.rs
@@ -410,6 +410,7 @@ impl Epoch {
         }
     }
 
+    #[allow(clippy::unnecessary_wraps)]
     pub(super) fn evaluate<'a>(self) -> Result<Cow<'a, json::Value>, ExecutingExpressionError> {
         let start = SystemTime::now();
         let since_the_epoch = start

--- a/lib/config/src/select_parser.rs
+++ b/lib/config/src/select_parser.rs
@@ -36,7 +36,7 @@ type ProviderStreamStream<Ar> = Box<
 >;
 
 pub trait ProviderStream<Ar: Clone + Send + Unpin + 'static> {
-    #[allow(clippy::wrong-self-convention)]
+    #[allow(clippy::wrong_self_convention)]
     fn into_stream(&self) -> ProviderStreamStream<Ar>;
 }
 

--- a/lib/config/src/select_parser.rs
+++ b/lib/config/src/select_parser.rs
@@ -36,7 +36,7 @@ type ProviderStreamStream<Ar> = Box<
 >;
 
 pub trait ProviderStream<Ar: Clone + Send + Unpin + 'static> {
-    #[allow(clippy::unnecessary_wraps)]
+    #[allow(clippy::wrong-self-convention)]
     fn into_stream(&self) -> ProviderStreamStream<Ar>;
 }
 

--- a/lib/config/src/select_parser.rs
+++ b/lib/config/src/select_parser.rs
@@ -36,6 +36,7 @@ type ProviderStreamStream<Ar> = Box<
 >;
 
 pub trait ProviderStream<Ar: Clone + Send + Unpin + 'static> {
+    #[allow(clippy::unnecessary_wraps)]
     fn into_stream(&self) -> ProviderStreamStream<Ar>;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,6 +498,7 @@ fn create_config_watcher(
                 Err(_) => continue,
             };
 
+            // Check the last modified. If we don't have one, or it hasn't changed, continue to the next loop
             match last_modified {
                 Some(lm) if modified == lm => continue,
                 None => {
@@ -507,6 +508,7 @@ fn create_config_watcher(
                 _ => last_modified = Some(modified),
             }
 
+            // Last modified has changed
             if file.seek(SeekFrom::Start(0)).is_err() {
                 continue;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,7 @@ impl Endpoints {
         }
     }
 
+    #[allow(clippy::unnecessary_wraps)]
     fn build<F>(
         self,
         filter_fn: F,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -19,7 +19,7 @@ fn run_test(path: &str) -> (bool, String, String) {
             stats_file: "integration.json".into(),
             stats_file_format: pewpew::StatsFileFormat::Json,
             start_at: None,
-            watch_config_file: false,
+            watch_config_file: true,
         };
         let exec_config = pewpew::ExecConfig::Run(run_config);
 


### PR DESCRIPTION
https://github.com/FamilySearch/pewpew/issues/46

- Changed the integration test to turn on watch_config_file causes on_demand to fail
- Fixed the issue with --watch and on_demand
  - When there was a "watcher" it would also add an on_demand listender which would catch the messages preventing the real endpoint from receiving the message and firing.
  - We now only create a lisenter when something tries to listen (i.e. an endpoint). The config watcher never actually runs anything and therefor never "listens".
- Added config provider logging of on_demand counts.
