### PR TITLE
Reverted some of the name fixes due to Splunk Dashboard issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
 dependencies = [
  "typenum",
 ]
@@ -1420,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom",
 ]

--- a/lib/channel/src/lib.rs
+++ b/lib/channel/src/lib.rs
@@ -417,23 +417,24 @@ impl<T: Serialize> Sink<T> for Sender<T> {
     }
 }
 
-// used to get statistics about a channel
+// used to get statistics about a channel (provider stats)
 pub struct ChannelStatsReader<T: Serialize> {
-    name: String,
+    // While a better description would be the channel "name" here, the Splunk dashboards rely on the keyword "provider"
+    provider: String,
     channel: Arc<Channel<T>>,
 }
 
 impl<T: Serialize> ChannelStatsReader<T> {
-    pub fn new(name: String, receiver: &Receiver<T>) -> Self {
+    pub fn new(provider: String, receiver: &Receiver<T>) -> Self {
         ChannelStatsReader {
-            name,
+            provider,
             channel: receiver.channel.clone(),
         }
     }
 
     pub fn get_stats(&self, timestamp: u64) -> ChannelStats {
         ChannelStats {
-            name: &self.name,
+            provider: &self.provider,
             timestamp,
             len: self.channel.len(),
             limit: self.channel.limit(),
@@ -449,7 +450,8 @@ impl<T: Serialize> ChannelStatsReader<T> {
 #[serde(rename_all = "camelCase")]
 pub struct ChannelStats<'a> {
     pub timestamp: u64,
-    pub name: &'a str,
+    // While a better description would be the channel "name" here, the Splunk dashboards rely on the keyword "provider"
+    pub provider: &'a str,
     pub len: usize,
     pub limit: usize,
     pub receiver_count: usize,

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -486,7 +486,7 @@ impl Stats {
                 format!(
                     "\n- {}:\n  length: {}\n  limit: {}\n  \
                      number of receivers: {}\n  number of senders: {}\n",
-                    Paint::yellow(stats.name).dimmed(),
+                    Paint::yellow(stats.provider).dimmed(),
                     stats.len,
                     stats.limit,
                     stats.receiver_count,


### PR DESCRIPTION
Commit https://github.com/FamilySearch/pewpew/commit/3aa591614ecb55309ee4fe4d8ab420abd0ffdc24 changed the name of the provider name from 'provider' to 'name' breaking
our agent dashboard. Reverted it to fix the dashboard.