### PR TITLE
Update for release of 0.5.8

### DIFF
--- a/.github/workflows/update-guide.yml
+++ b/.github/workflows/update-guide.yml
@@ -49,7 +49,7 @@ jobs:
 
           # build the results viewer (which includes putting the output into the book's src)
           cd $RESULTS_VIEWER_DIR
-          npm install
+          npm ci
           npm run build
 
           # build the book

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "pewpew"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "atty",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pewpew"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2018"
 default-run = "pewpew"
 publish = false

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Changes:
 Bug fixes:
 - Refactor providers to resolve issues where some tests would see memory leaks and extraneous CPU usage.
 - Fix regression from v0.5.6 where sending a file as part of a request's body did not work.
+- Fix the config parser web assembly issue with using `epoch` in logger file names.
 
 ### v0.5.7
 Bug fixes:


### PR DESCRIPTION
- Changed the guild release to use npm ci rather than install for continuous integration environments
- Updated the Readme to include the config parser fix
- Updated the cargo version in preparation for releasing 0.5.8!