### PR TITLE
Binary logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f3675cfef6a30c8031cf9e6493ebdc3bb3272a3fea3923c4210d1830e6a472"
+checksum = "6c06815895acec637cd6ed6e9662c935b866d20a106f8361892893a7d9234964"
 dependencies = [
  "bytes",
  "fnv",
@@ -905,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.102"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
+checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
 
 [[package]]
 name = "libflate"
@@ -1285,9 +1285,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
 
 [[package]]
 name = "ppv-lite86"
@@ -1324,9 +1324,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
@@ -1549,9 +1549,9 @@ checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "socket2"
@@ -1577,9 +1577,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
+checksum = "a4eac2e6c19f5c3abc0c229bea31ff0b9b091c7b14990e8924b92902a303a0c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1650,9 +1650,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5241dd6f21443a3606b432718b166d3cedc962fd4b8bea54a8bc7f514ebda986"
+checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1685,9 +1685,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+checksum = "154794c8f499c2619acd19e839294703e9e32e7630ef5f46ea80d4ef0fbee5eb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1749,9 +1749,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46125608c26121c81b0c6d693eab5a420e416da7e43c426d2e8f7df8da8a3acf"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1623,6 +1623,7 @@ dependencies = [
  "futures-timer",
  "http",
  "hyper",
+ "log",
  "parking_lot",
  "tokio",
  "url",

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Pewpew is an HTTP load test tool designed for ease of use and high performance. 
 Changes:
 - Added logging to the binaries. All binaries now support turning on logging via the `RUST_LOG` environment variable. The default value is `error`. Other available options are `warn`, `info`, `debug`, `trace`, and `off`.
 - Changed the default try script output to log `headers_all` rather than `headers`. There were complaints about not seeing duplicate headers causing confusion over what was being sent.
+- Change try script output to go through stdout instead of stderr.
 
 ### v0.5.9
 Bug fixes:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Changes:
 - Added logging to the binaries. All binaries now support turning on logging via the `RUST_LOG` environment variable. The default value is `error`. Other available options are `warn`, `info`, `debug`, `trace`, and `off`.
 - Changed the default try script output to log `headers_all` rather than `headers`. There were complaints about not seeing duplicate headers causing confusion over what was being sent.
 - Change try script output to go through stdout instead of stderr.
+- Modified the Config WebAssembly (config-wasm) to also return file body paths from the `getInputFiles()` method.
 
 ### v0.5.9
 Bug fixes:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ Pewpew is an HTTP load test tool designed for ease of use and high performance. 
 ![Release](https://github.com/FamilySearch/pewpew/workflows/Release/badge.svg)
 
 ## Changelog
+### v0.5.10
+Changes:
+- Added logging to the binaries. All binaries now support turning on logging via the `RUST_LOG` environment variable. The default value is `error`. Other available options are `warn`, `info`, `debug`, `trace`, and `off`.
+- Changed the default try script output to log `headers_all` rather than `headers`. There were complaints about not seeing duplicate headers causing confusion over what was being sent.
+
 ### v0.5.9
 Bug fixes:
 - Upgrade tokio and other dependencies

--- a/guide/src/cli.md
+++ b/guide/src/cli.md
@@ -27,7 +27,7 @@ USAGE:
 
 OPTIONS:
     -h, --help                             Prints help information
-    -f, --output-format <FORMAT>           Formatting for stats printed to stderr [default: human]  [possible values:
+    -f, --output-format <FORMAT>           Formatting for stats printed to stdout [default: human]  [possible values:
                                            human, json]
     -d, --results-directory <DIRECTORY>    Directory to store results and logs
     -t, --start-at <START_AT>              Specify the time the test should start at
@@ -42,7 +42,7 @@ ARGS:
     <CONFIG>    Load test config file to use
 ```
 
-The `-f`, `--output-format` parameter allows changing the formatting of the stats which are printed to stderr.
+The `-f`, `--output-format` parameter allows changing the formatting of the stats which are printed to stdout.
 
 The `-d`, `--results-directory` parameter will store the results file and any output logs in the specified directory. If the directory does not exist it is created.
 
@@ -58,7 +58,7 @@ USAGE:
     pewpew try [OPTIONS] <CONFIG>
 
 OPTIONS:
-    -o, --file <FILE>                      Send results to the specified file instead of stderr
+    -o, --file <FILE>                      Send results to the specified file instead of stdout
     -f, --format <FORMAT>                  Specify the format for the try run output [default: human]  [possible values:
                                            human, json]
     -h, --help                             Prints help information

--- a/lib/config-wasm/src/lib.rs
+++ b/lib/config-wasm/src/lib.rs
@@ -1,6 +1,6 @@
 use config::{BodyTemplate, LoadTest, Provider};
 use js_sys::Map;
-use log::{LevelFilter, debug};
+use log::{debug, LevelFilter};
 use std::{path::PathBuf, str::FromStr};
 use wasm_bindgen::{prelude::wasm_bindgen, throw_str, JsValue, UnwrapThrowExt};
 
@@ -88,21 +88,23 @@ impl Config {
     pub fn get_input_files(&self) -> Box<[JsValue]> {
         // We also need to include file bodies so we can validate that we have those as well.
         // Endpoint file bodies - BodyTemplate(File)
-        let mut body_files: Vec<JsValue> = self.0
+        let mut body_files: Vec<JsValue> = self
+            .0
             .endpoints
             .iter()
-            .filter_map(| endpoint| {
+            .filter_map(|endpoint| {
                 if let BodyTemplate::File(_, template) = &endpoint.body {
-                  // The path is the base path, the template.pieces has the real path
-                  debug!("endpoint::body::file.template={:?}", template);
-                  Some(template.evaluate_with_star().into())
+                    // The path is the base path, the template.pieces has the real path
+                    debug!("endpoint::body::file.template={:?}", template);
+                    Some(template.evaluate_with_star().into())
                 } else {
-                  None
+                    None
                 }
             })
             .collect::<Vec<_>>();
         // file providers
-        let mut provider_files = self.0
+        let mut provider_files = self
+            .0
             .providers
             .iter()
             .filter_map(|(_, v)| {

--- a/lib/config/src/lib.rs
+++ b/lib/config/src/lib.rs
@@ -21,6 +21,7 @@ pub use select_parser::{
     REQUEST_HEADERS_ALL, REQUEST_STARTLINE, REQUEST_URL, RESPONSE_BODY, RESPONSE_HEADERS,
     RESPONSE_HEADERS_ALL, RESPONSE_STARTLINE, STATS,
 };
+use serde::Serialize;
 use serde_json as json;
 use yaml_rust::scanner::{Marker, Scanner};
 
@@ -28,6 +29,7 @@ use log::{debug, error, LevelFilter};
 use std::{
     borrow::Cow,
     collections::{BTreeMap, BTreeSet},
+    fmt,
     iter,
     num::{NonZeroU16, NonZeroUsize},
     path::{Path, PathBuf},
@@ -562,8 +564,14 @@ impl From<RangeProviderPreProcessed> for RangeProvider {
     }
 }
 
+impl fmt::Display for RangeProvider {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+      write!(f, "{}", serde_json::to_string(&self.1).unwrap_or_default())
+  }
+}
+
 #[cfg_attr(debug_assertions, derive(Debug))]
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Serialize)]
 pub struct RangeProviderPreProcessed {
     start: i64,
     end: i64,
@@ -2384,11 +2392,18 @@ pub struct FileProvider {
     pub unique: bool,
 }
 
+#[derive(Serialize)]
 pub struct Logger {
     pub to: String,
     pub pretty: bool,
     pub limit: Option<usize>,
     pub kill: bool,
+}
+
+impl fmt::Display for Logger {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+      write!(f, "{}", serde_json::to_string(&self).unwrap_or_default())
+  }
 }
 
 impl Logger {
@@ -2465,6 +2480,17 @@ pub enum BodyTemplate {
     Multipart(MultipartBody),
     None,
     String(Template),
+}
+
+impl fmt::Display for BodyTemplate {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+      match &self {
+          BodyTemplate::File(_, _) => write!(f, "BodyTemplate::File"),
+          BodyTemplate::Multipart(_) => write!(f, "BodyTemplate::Multipart"),
+          BodyTemplate::None => write!(f, "BodyTemplate::None"),
+          BodyTemplate::String(_) => write!(f, "BodyTemplate::String"),
+      }
+  }
 }
 
 impl Endpoint {
@@ -2702,6 +2728,7 @@ impl LoadTest {
         config_path: &Path,
         env_vars: &BTreeMap<String, String>,
     ) -> Result<Self, Error> {
+        debug!("config::LoadTest::from_config: {}", config_path.to_str().unwrap_or_default());
         let iter = std::str::from_utf8(bytes).unwrap().chars();
 
         let mut decoder = YamlDecoder::new(iter);

--- a/lib/config/src/lib.rs
+++ b/lib/config/src/lib.rs
@@ -29,8 +29,7 @@ use log::{debug, error, LevelFilter};
 use std::{
     borrow::Cow,
     collections::{BTreeMap, BTreeSet},
-    fmt,
-    iter,
+    fmt, iter,
     num::{NonZeroU16, NonZeroUsize},
     path::{Path, PathBuf},
     str::FromStr,
@@ -565,9 +564,9 @@ impl From<RangeProviderPreProcessed> for RangeProvider {
 }
 
 impl fmt::Display for RangeProvider {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-      write!(f, "{}", serde_json::to_string(&self.1).unwrap_or_default())
-  }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", serde_json::to_string(&self.1).unwrap_or_default())
+    }
 }
 
 #[cfg_attr(debug_assertions, derive(Debug))]
@@ -2401,9 +2400,9 @@ pub struct Logger {
 }
 
 impl fmt::Display for Logger {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-      write!(f, "{}", serde_json::to_string(&self).unwrap_or_default())
-  }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", serde_json::to_string(&self).unwrap_or_default())
+    }
 }
 
 impl Logger {
@@ -2483,14 +2482,14 @@ pub enum BodyTemplate {
 }
 
 impl fmt::Display for BodyTemplate {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-      match &self {
-          BodyTemplate::File(_, _) => write!(f, "BodyTemplate::File"),
-          BodyTemplate::Multipart(_) => write!(f, "BodyTemplate::Multipart"),
-          BodyTemplate::None => write!(f, "BodyTemplate::None"),
-          BodyTemplate::String(_) => write!(f, "BodyTemplate::String"),
-      }
-  }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self {
+            BodyTemplate::File(_, _) => write!(f, "BodyTemplate::File"),
+            BodyTemplate::Multipart(_) => write!(f, "BodyTemplate::Multipart"),
+            BodyTemplate::None => write!(f, "BodyTemplate::None"),
+            BodyTemplate::String(_) => write!(f, "BodyTemplate::String"),
+        }
+    }
 }
 
 impl Endpoint {
@@ -2728,7 +2727,10 @@ impl LoadTest {
         config_path: &Path,
         env_vars: &BTreeMap<String, String>,
     ) -> Result<Self, Error> {
-        debug!("config::LoadTest::from_config: {}", config_path.to_str().unwrap_or_default());
+        debug!(
+            "config::LoadTest::from_config: {}",
+            config_path.to_str().unwrap_or_default()
+        );
         let iter = std::str::from_utf8(bytes).unwrap().chars();
 
         let mut decoder = YamlDecoder::new(iter);

--- a/lib/test_common/Cargo.toml
+++ b/lib/test_common/Cargo.toml
@@ -17,3 +17,4 @@ http = "0.2"
 parking_lot = "0.11"
 tokio = { version = "1", features = ["full"] }
 url = "2"
+log = "0.4"

--- a/lib/test_common/test_common.rs
+++ b/lib/test_common/test_common.rs
@@ -82,8 +82,14 @@ pub fn start_test_server(
                     .unwrap(),
             };
             debug!("{:?}", response);
-            info!("method=\"{}\" uri=\"{}\" status=\"{}\" request_headers={:?} response_headers={:?}",
-                method, uri, response.status(), headers, response.headers());
+            info!(
+                "method=\"{}\" uri=\"{}\" status=\"{}\" request_headers={:?} response_headers={:?}",
+                method,
+                uri,
+                response.status(),
+                headers,
+                response.headers()
+            );
             Ok::<_, Error>(response)
         });
         Ok::<_, Error>(service)

--- a/lib/test_common/test_common.rs
+++ b/lib/test_common/test_common.rs
@@ -97,6 +97,7 @@ pub fn start_test_server(
 
     let future = select(server, rx);
 
+    debug!("start_test_server tokio::spawn future");
     let handle = tokio::spawn(future).map(|_| ());
 
     (port, tx, handle)

--- a/lib/test_common/test_common.rs
+++ b/lib/test_common/test_common.rs
@@ -1,3 +1,4 @@
+use log::{debug, info};
 use std::{future::Future, io, str::FromStr, sync::Arc, time::Duration};
 
 use futures::{channel::oneshot, future::select, FutureExt};
@@ -32,6 +33,9 @@ async fn echo_route(req: Request<Body>) -> Response<Body> {
             _ => (),
         }
     }
+    if echo.is_some() {
+        debug!("Echo Body = {}", echo.clone().unwrap_or_default());
+    }
     let mut response = match (req.method(), echo) {
         (&http::Method::GET, Some(b)) => Response::builder()
             .status(StatusCode::OK)
@@ -50,6 +54,9 @@ async fn echo_route(req: Request<Body>) -> Response<Body> {
     };
     let ms = wait.and_then(|c| FromStr::from_str(&*c).ok()).unwrap_or(0);
     let old_body = std::mem::replace(response.body_mut(), Body::empty());
+    if ms > 0 {
+        debug!("waiting {} ms", ms);
+    }
     Delay::new(Duration::from_millis(ms)).await;
     let _ = std::mem::replace(response.body_mut(), old_body);
     response
@@ -63,6 +70,10 @@ pub fn start_test_server(
 
     let make_svc = make_service_fn(|_: &AddrStream| async {
         let service = service_fn(|req: Request<Body>| async {
+            debug!("{:?}", req);
+            let method = req.method().to_string();
+            let uri = req.uri().to_string();
+            let headers = req.headers().clone();
             let response = match req.uri().path() {
                 "/" => echo_route(req).await,
                 _ => Response::builder()
@@ -70,6 +81,9 @@ pub fn start_test_server(
                     .body(Body::empty())
                     .unwrap(),
             };
+            debug!("{:?}", response);
+            info!("method=\"{}\" uri=\"{}\" status=\"{}\" request_headers={:?} response_headers={:?}",
+                method, uri, response.status(), headers, response.headers());
             Ok::<_, Error>(response)
         });
         Ok::<_, Error>(service)

--- a/src/bin/pewpew.rs
+++ b/src/bin/pewpew.rs
@@ -3,6 +3,7 @@ use std::{convert::TryInto, fs::create_dir_all, io, path::PathBuf, time::UNIX_EP
 use clap::{crate_version, App, AppSettings, Arg, SubCommand};
 use config::duration_from_string;
 use futures::channel::mpsc as futures_channel;
+use log::{debug, info};
 use pewpew::{
     create_run, ExecConfig, RunConfig, RunOutputFormat, StatsFileFormat, TryConfig, TryFilter,
     TryRunFormat,
@@ -174,10 +175,13 @@ fn main() {
         )
         .expect("output_format cli arg unrecognized");
         match output_format {
-            RunOutputFormat::Json => json_env_logger::init(),
+            RunOutputFormat::Json => {
+              json_env_logger::init();
+              json_env_logger::panic_hook();
+            },
             _ => env_logger::init(),
         }
-        log::warn!("log::max_level() = {}", log::max_level());
+        info!("log::max_level() = {}", log::max_level());
         let stats_file = matches
             .value_of_os("stats-file")
             .map(PathBuf::from)
@@ -215,6 +219,7 @@ fn main() {
             stats_file_format,
             watch_config_file,
         };
+        debug!("{{\"run_config\":{}}}", run_config);
         ExecConfig::Run(run_config)
     } else if let Some(matches) = matches.subcommand_matches("try") {
         let config_file: PathBuf = matches
@@ -262,10 +267,13 @@ fn main() {
             .and_then(|f| f.try_into().ok())
             .unwrap_or_default();
         match format {
-            TryRunFormat::Json => json_env_logger::init(),
+            TryRunFormat::Json => {
+              json_env_logger::init();
+              json_env_logger::panic_hook();
+            },
             _ => env_logger::init(),
         }
-        log::warn!("log::max_level() = {}", log::max_level());
+        info!("log::max_level()={}", log::max_level());
         let file = matches.value_of("file").map(Into::into);
         let try_config = TryConfig {
             config_file,
@@ -275,6 +283,7 @@ fn main() {
             loggers_on,
             results_dir,
         };
+        debug!("{{\"try_config\":{}}}", try_config);
         ExecConfig::Try(try_config)
     } else {
         unreachable!();
@@ -288,9 +297,12 @@ fn main() {
         .thread_name("pewpew-worker")
         .build()
         .unwrap();
+    debug!("rt.block_on start",);
     let result = rt.block_on(f);
+    debug!("rt.block_on finished",);
     // shutdown the runtime in case there are any hanging threads/tasks
     rt.shutdown_timeout(Default::default());
+    debug!("rt.shutdown_timeout finished",);
 
     if result.is_err() {
         std::process::exit(1)

--- a/src/bin/pewpew.rs
+++ b/src/bin/pewpew.rs
@@ -107,7 +107,7 @@ fn main() {
                 Arg::with_name("file")
                     .short("o")
                     .long("file")
-                    .help("Send results to the specified file instead of stderr")
+                    .help("Send results to the specified file instead of stdout")
                     .value_name("FILE")
             )
             .arg(

--- a/src/bin/pewpew.rs
+++ b/src/bin/pewpew.rs
@@ -176,9 +176,9 @@ fn main() {
         .expect("output_format cli arg unrecognized");
         match output_format {
             RunOutputFormat::Json => {
-              json_env_logger::init();
-              json_env_logger::panic_hook();
-            },
+                json_env_logger::init();
+                json_env_logger::panic_hook();
+            }
             _ => env_logger::init(),
         }
         info!("log::max_level() = {}", log::max_level());
@@ -268,9 +268,9 @@ fn main() {
             .unwrap_or_default();
         match format {
             TryRunFormat::Json => {
-              json_env_logger::init();
-              json_env_logger::panic_hook();
-            },
+                json_env_logger::init();
+                json_env_logger::panic_hook();
+            }
             _ => env_logger::init(),
         }
         info!("log::max_level()={}", log::max_level());
@@ -297,12 +297,12 @@ fn main() {
         .thread_name("pewpew-worker")
         .build()
         .unwrap();
-    debug!("rt.block_on start",);
+    debug!("rt.block_on start");
     let result = rt.block_on(f);
-    debug!("rt.block_on finished",);
+    debug!("rt.block_on finished. result: {:?}", result);
     // shutdown the runtime in case there are any hanging threads/tasks
     rt.shutdown_timeout(Default::default());
-    debug!("rt.shutdown_timeout finished",);
+    debug!("rt.shutdown_timeout finished");
 
     if result.is_err() {
         std::process::exit(1)

--- a/src/bin/test_server.rs
+++ b/src/bin/test_server.rs
@@ -1,11 +1,13 @@
+use log::debug;
 use test_common::start_test_server;
 use tokio::runtime::Runtime;
 
 fn main() {
+    env_logger::init();
     let rt = Runtime::new().unwrap();
     rt.block_on(async {
-        // todo!("get working");
         let port = std::env::var("PORT").ok().and_then(|s| s.parse().ok());
+        debug!("port = {}", port.unwrap_or_default());
         let (port, rx, handle) = start_test_server(port);
 
         println!("Listening on port {}", port);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![allow(unused_attributes)]
 #![type_length_limit = "19550232"]
 #![allow(clippy::type_complexity)]
 
@@ -28,8 +29,10 @@ use hyper::{client::HttpConnector, Body, Client};
 use hyper_tls::HttpsConnector;
 use itertools::Itertools;
 use line_writer::{blocking_writer, MsgType};
+use log::{debug, error, info, warn};
 use mod_interval::{ModInterval, PerX};
 use native_tls::TlsConnector;
+use serde::Serialize;
 use serde_json as json;
 use tokio::{sync::broadcast, task::spawn_blocking};
 use tokio_stream::wrappers::{BroadcastStream, IntervalStream};
@@ -40,6 +43,7 @@ use std::{
     cell::RefCell,
     collections::{BTreeMap, BTreeSet},
     convert::TryFrom,
+    fmt,
     fs::File,
     future::Future,
     io::{Error as IOError, ErrorKind as IOErrorKind, Read, Seek, SeekFrom, Write},
@@ -148,7 +152,7 @@ impl Endpoints {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize)]
 pub enum RunOutputFormat {
     Human,
     Json,
@@ -172,14 +176,14 @@ impl TryFrom<&str> for RunOutputFormat {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum StatsFileFormat {
     // Html,
     Json,
     // None,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum TryRunFormat {
     Human,
     Json,
@@ -203,7 +207,7 @@ impl TryFrom<&str> for TryRunFormat {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct RunConfig {
     pub config_file: PathBuf,
     pub output_format: RunOutputFormat,
@@ -214,13 +218,19 @@ pub struct RunConfig {
     pub watch_config_file: bool,
 }
 
-#[derive(Clone)]
+impl fmt::Display for RunConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", serde_json::to_string(&self).unwrap_or_default())
+    }
+}
+
+#[derive(Clone, Serialize)]
 pub enum TryFilter {
     Eq(String, String),
     Ne(String, String),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize)]
 pub struct TryConfig {
     pub config_file: PathBuf,
     pub file: Option<String>,
@@ -230,9 +240,22 @@ pub struct TryConfig {
     pub results_dir: Option<PathBuf>,
 }
 
+impl fmt::Display for TryConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", serde_json::to_string(&self).unwrap_or_default())
+    }
+}
+
+#[derive(Serialize)]
 pub enum ExecConfig {
     Run(RunConfig),
     Try(TryConfig),
+}
+
+impl fmt::Display for ExecConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", serde_json::to_string(&self).unwrap_or_default())
+    }
 }
 
 impl ExecConfig {
@@ -268,18 +291,29 @@ async fn _create_run(
     test_ended_tx: broadcast::Sender<Result<TestEndReason, TestError>>,
     mut test_ended_rx: BroadcastStream<Result<TestEndReason, TestError>>,
 ) -> Result<TestEndReason, TestError> {
+    debug!("{{\"_create_run enter");
     let config_file = exec_config.get_config_file().clone();
     let config_file2 = config_file.clone();
+    debug!("{{\"_create_run spawn_blocking start");
     let (file, config_bytes) = spawn_blocking(|| {
-        let mut file = File::open(config_file.clone())
-            .map_err(|_| TestError::InvalidConfigFilePath(config_file.clone()))?;
+            debug!("{{\"_create_run spawn_blocking enter");
+            let mut file = File::open(config_file.clone())
+            .map_err(|err| {
+                error!("File::open({}) error: {}", config_file.clone().to_str().unwrap_or_default(), err);
+                TestError::InvalidConfigFilePath(config_file.clone())
+            })?;
         let mut bytes = Vec::new();
         file.read_to_end(&mut bytes)
-            .map_err(|e| TestError::CannotOpenFile(config_file, e.into()))?;
+            .map_err(|e| {
+                error!("File::read_to_end({}) error: {}", config_file.clone().to_str().unwrap_or_default(), e);
+                TestError::CannotOpenFile(config_file, e.into())
+            })?;
+        debug!("{{\"_create_run spawn_blocking exit");
         Ok::<_, TestError>((file, bytes))
     })
     .await
     .map_err(move |e| {
+        warn!("config file error: {}", e);
         let e = IOError::new(IOErrorKind::Other, e);
         TestError::CannotOpenFile(config_file2, e.into())
     })??;
@@ -287,6 +321,7 @@ async fn _create_run(
     // watch for ctrl-c and kill the test
     let test_ended_tx2 = test_ended_tx.clone();
     let mut test_ended_rx2 = BroadcastStream::new(test_ended_tx.subscribe());
+    debug!("_create_run tokio::spawn future::poll_fn ctrl-c");
     tokio::spawn(future::poll_fn(move |cx| {
         match ctrlc_channel.poll_next_unpin(cx) {
             Poll::Ready(r) => {
@@ -299,13 +334,17 @@ async fn _create_run(
         }
     }));
 
-    let env_vars = std::env::vars_os()
+    let env_vars:BTreeMap<String, String> = std::env::vars_os()
         .map(|(k, v)| (k.to_string_lossy().into(), v.to_string_lossy().into()))
         .collect();
+    // Don't log the values in case there are passwords
+    debug!("env_vars={:?}", env_vars.clone().keys());
+    log::trace!("env_vars={:?}", env_vars.clone());
     let output_format = exec_config.get_output_format();
     let config_file_path = exec_config.get_config_file().clone();
     let mut config =
         config::LoadTest::from_config(&config_bytes, exec_config.get_config_file(), &env_vars)?;
+    debug!("config::LoadTest::from_config finished");
     let test_runner = match exec_config {
         ExecConfig::Try(t) => {
             create_try_run_future(config, t, test_ended_tx.clone(), stdout, stderr).map(Either::A)
@@ -360,6 +399,7 @@ async fn _create_run(
     };
     match test_runner {
         Ok(f) => {
+            debug!("_create_run tokio::spawn test_runner");
             tokio::spawn(f);
             let mut test_result = Ok(TestEndReason::Completed);
             while let Some(v) = test_ended_rx.next().await {
@@ -388,6 +428,7 @@ where
     So: Write + Send + 'static,
     Se: Write + Send + 'static,
 {
+    debug!("{{\"method\":\"create_run enter\",\"exec_config\":{}}}", exec_config);
     let (test_ended_tx, test_ended_rx) = broadcast::channel(1);
     let test_ended_rx = BroadcastStream::new(test_ended_rx);
     let output_format = exec_config.get_output_format();
@@ -406,6 +447,7 @@ where
     match test_result {
         Err(e) => {
             // send the test end message to ensure the stats channel closes
+            error!("{}", e);
             let _ = test_ended_tx.send(Ok(TestEndReason::Completed));
             let msg = match output_format {
                 RunOutputFormat::Human => format!("\n{} {}\n", Paint::red("Fatal error").bold(), e),
@@ -455,7 +497,9 @@ where
             };
             let _ = stderr.send(MsgType::Final(msg)).await;
         }
-        _ => (),
+        // Instead of implementing Display for TestEndReason, just log these other two
+        Ok(TestEndReason::Completed) => info!("Test Ended with: Completed"),
+        Ok(TestEndReason::ConfigUpdate(_)) => info!("Test Ended with: ConfigUpdate"),
     };
     drop(stderr);
     // wait for all stderr and stdout output to be written
@@ -491,8 +535,13 @@ fn create_config_watcher(
             Poll::Ready(_) => Poll::Ready(None),
         },
     });
+    debug!("{{\"create_config_watcher spawn_blocking start");
     spawn_blocking(move || {
+        debug!("{{\"create_config_watcher spawn_blocking enter");
+        let mut stream_counter = 1;
         for _ in block_on_stream(stream) {
+            debug!("{{\"create_config_watcher block_on_stream: {}", stream_counter);
+            stream_counter += 1;
             let modified = match file.metadata() {
                 Ok(m) => match m.modified() {
                     Ok(m) => m,
@@ -623,8 +672,10 @@ fn create_config_watcher(
                 }
             };
 
+            debug!("create_config_watcher tokio::spawn create_load_test_future");
             tokio::spawn(f);
         }
+        debug!("{{\"create_config_watcher spawn_blocking exit");
     });
 }
 
@@ -635,6 +686,7 @@ fn create_try_run_future(
     stdout: FCSender<MsgType>,
     stderr: FCSender<MsgType>,
 ) -> Result<impl Future<Output = ()>, TestError> {
+    debug!("create_try_run_future start");
     // create a logger for the try run
     // request.headers only logs single Accept Headers due to JSON requirements. Use headers_all instead
     let select = if let TryRunFormat::Human = try_config.format {
@@ -669,8 +721,10 @@ fn create_try_run_future(
     let to = try_config.file.unwrap_or_else(|| "stdout".into());
     let logger = config::LoggerPreProcessed::from_str(select, &to).unwrap();
     if !try_config.loggers_on {
+        debug!("loggers_on: {}. Clearing Loggers", try_config.loggers_on);
         config.clear_loggers();
     }
+    debug!("try logger: {:?}", logger);
     config.add_logger("try_run".into(), logger)?;
 
     let config_config = config.config;
@@ -793,6 +847,7 @@ fn create_try_run_future(
             _ => Poll::Pending,
         },
     });
+    debug!("create_try_run_future finish");
     Ok(f)
 }
 
@@ -805,6 +860,7 @@ fn create_load_test_future(
     stdout: FCSender<MsgType>,
     stderr: FCSender<MsgType>,
 ) -> Result<impl Future<Output = ()>, TestError> {
+    debug!("create_load_test_future start");
     config.ok_for_loadtest()?;
 
     let mut duration = config.get_duration();
@@ -896,6 +952,7 @@ fn create_load_test_future(
         },
     });
 
+    debug!("create_load_test_future finish");
     Ok(f)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -636,28 +636,29 @@ fn create_try_run_future(
     stderr: FCSender<MsgType>,
 ) -> Result<impl Future<Output = ()>, TestError> {
     // create a logger for the try run
+    // request.headers only logs single Accept Headers due to JSON requirements. Use headers_all instead
     let select = if let TryRunFormat::Human = try_config.format {
         r#""`\
          Request\n\
          ========================================\n\
          ${request['start-line']}\n\
-         ${join(request.headers, '\n', ': ')}\n\
+         ${join(request.headers_all, '\n', ': ')}\n\
          ${if(request.body != '', '\n${request.body}\n', '')}\n\
          Response (RTT: ${stats.rtt}ms)\n\
          ========================================\n\
          ${response['start-line']}\n\
-         ${join(response.headers, '\n', ': ')}\n\
+         ${join(response.headers_all, '\n', ': ')}\n\
          ${if(response.body != '', '\n${response.body}', '')}\n\n`""#
     } else {
         r#"{
             "request": {
                 "start-line": "request['start-line']",
-                "headers": "request.headers",
+                "headers": "request.headers_all",
                 "body": "request.body"
             },
             "response": {
                 "start-line": "response['start-line']",
-                "headers": "response.headers",
+                "headers": "response.headers_all",
                 "body": "response.body"
             },
             "stats": {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -666,7 +666,7 @@ fn create_try_run_future(
             }
         })"#
     };
-    let to = try_config.file.unwrap_or_else(|| "stderr".into());
+    let to = try_config.file.unwrap_or_else(|| "stdout".into());
     let logger = config::LoggerPreProcessed::from_str(select, &to).unwrap();
     if !try_config.loggers_on {
         config.clear_loggers();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,18 +296,24 @@ async fn _create_run(
     let config_file2 = config_file.clone();
     debug!("{{\"_create_run spawn_blocking start");
     let (file, config_bytes) = spawn_blocking(|| {
-            debug!("{{\"_create_run spawn_blocking enter");
-            let mut file = File::open(config_file.clone())
-            .map_err(|err| {
-                error!("File::open({}) error: {}", config_file.clone().to_str().unwrap_or_default(), err);
-                TestError::InvalidConfigFilePath(config_file.clone())
-            })?;
+        debug!("{{\"_create_run spawn_blocking enter");
+        let mut file = File::open(config_file.clone()).map_err(|err| {
+            error!(
+                "File::open({}) error: {}",
+                config_file.clone().to_str().unwrap_or_default(),
+                err
+            );
+            TestError::InvalidConfigFilePath(config_file.clone())
+        })?;
         let mut bytes = Vec::new();
-        file.read_to_end(&mut bytes)
-            .map_err(|e| {
-                error!("File::read_to_end({}) error: {}", config_file.clone().to_str().unwrap_or_default(), e);
-                TestError::CannotOpenFile(config_file, e.into())
-            })?;
+        file.read_to_end(&mut bytes).map_err(|e| {
+            error!(
+                "File::read_to_end({}) error: {}",
+                config_file.to_str().unwrap_or_default(),
+                e
+            );
+            TestError::CannotOpenFile(config_file, e.into())
+        })?;
         debug!("{{\"_create_run spawn_blocking exit");
         Ok::<_, TestError>((file, bytes))
     })
@@ -334,7 +340,7 @@ async fn _create_run(
         }
     }));
 
-    let env_vars:BTreeMap<String, String> = std::env::vars_os()
+    let env_vars: BTreeMap<String, String> = std::env::vars_os()
         .map(|(k, v)| (k.to_string_lossy().into(), v.to_string_lossy().into()))
         .collect();
     // Don't log the values in case there are passwords
@@ -428,7 +434,10 @@ where
     So: Write + Send + 'static,
     Se: Write + Send + 'static,
 {
-    debug!("{{\"method\":\"create_run enter\",\"exec_config\":{}}}", exec_config);
+    debug!(
+        "{{\"method\":\"create_run enter\",\"exec_config\":{}}}",
+        exec_config
+    );
     let (test_ended_tx, test_ended_rx) = broadcast::channel(1);
     let test_ended_rx = BroadcastStream::new(test_ended_rx);
     let output_format = exec_config.get_output_format();
@@ -540,7 +549,10 @@ fn create_config_watcher(
         debug!("{{\"create_config_watcher spawn_blocking enter");
         let mut stream_counter = 1;
         for _ in block_on_stream(stream) {
-            debug!("{{\"create_config_watcher block_on_stream: {}", stream_counter);
+            debug!(
+                "{{\"create_config_watcher block_on_stream: {}",
+                stream_counter
+            );
             stream_counter += 1;
             let modified = match file.metadata() {
                 Ok(m) => match m.modified() {

--- a/src/line_writer.rs
+++ b/src/line_writer.rs
@@ -32,7 +32,7 @@ pub fn blocking_writer<W: Write + Send + 'static>(
     // start up the blocking task
     log::trace!("{{\"blocking_writer spawn_blocking start");
     spawn_blocking(move || {
-      log::trace!("{{\"blocking_writer spawn_blocking enter");
+        log::trace!("{{\"blocking_writer spawn_blocking enter");
         let mut final_msg = None;
 
         // read messages from the `Receiver`

--- a/src/line_writer.rs
+++ b/src/line_writer.rs
@@ -30,7 +30,9 @@ pub fn blocking_writer<W: Write + Send + 'static>(
     let (done_tx, done_rx) = oneshot::channel();
 
     // start up the blocking task
+    log::trace!("{{\"blocking_writer spawn_blocking start");
     spawn_blocking(move || {
+      log::trace!("{{\"blocking_writer spawn_blocking enter");
         let mut final_msg = None;
 
         // read messages from the `Receiver`
@@ -54,6 +56,7 @@ pub fn blocking_writer<W: Write + Send + 'static>(
             }
         }
         let _ = done_tx.send(());
+        log::trace!("{{\"blocking_writer spawn_blocking exit");
     });
     (tx, done_rx)
 }

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -247,7 +247,7 @@ fn into_stream<I: Iterator<Item = Result<json::Value, io::Error>> + Send + 'stat
     let (mut tx, rx) = channel(5);
     log::trace!("{{\"into_stream spawn_blocking start");
     spawn_blocking(move || {
-      log::trace!("{{\"into_stream spawn_blocking enter");
+        log::trace!("{{\"into_stream spawn_blocking enter");
         for value in iter {
             let value = value.map_err(|e| io::Error::new(io::ErrorKind::Other, e));
             // this should only error when the receiver is dropped, and in that case we can stop sending

--- a/src/request.rs
+++ b/src/request.rs
@@ -87,19 +87,13 @@ impl AutoReturn {
             EndpointProvidesSendOptions::Force => {
                 while let Some(json) = self.jsons.pop() {
                     log::trace!("AutoReturn::into_future::Force json={}", json);
-                    self
-                    .channel
-                    .force_send(json);
+                    self.channel.force_send(json);
                 }
             }
             EndpointProvidesSendOptions::IfNotFull => {
                 while let Some(json) = self.jsons.pop() {
                     log::trace!("AutoReturn::into_future::IfNotFull json={}", json);
-                    if self
-                    .channel
-                    .send(json)
-                    .now_or_never()
-                    .is_none() {
+                    if self.channel.send(json).now_or_never().is_none() {
                         break;
                     }
                 }
@@ -216,8 +210,8 @@ pub struct EndpointBuilder {
     start_stream: Option<Pin<Box<dyn Stream<Item = (Instant, Option<Instant>)> + Send>>>,
 }
 
-fn convert_to_debug<T>(value: &Vec<(String, T)>) -> Vec<String> {
-  value.iter().map(|(key, _)| key.clone().to_string()).collect()
+fn convert_to_debug<T>(value: &[(String, T)]) -> Vec<String> {
+    value.iter().map(|(key, _)| key.to_string()).collect()
 }
 
 impl EndpointBuilder {
@@ -691,7 +685,10 @@ impl Endpoint {
                 _ => None,
             })
             .collect();
-        debug!("into_future method=\"{}\" url=\"{:?}\" request_headers={:?} tags={:?}", method, url, headers, tags);
+        debug!(
+            "into_future method=\"{}\" url=\"{:?}\" request_headers={:?} tags={:?}",
+            method, url, headers, tags
+        );
         let rm = RequestMaker {
             url,
             method,

--- a/src/request.rs
+++ b/src/request.rs
@@ -6,6 +6,7 @@ mod response_handler;
 use self::body_handler::BodyHandler;
 use self::request_maker::RequestMaker;
 
+use log::debug;
 use request_maker::ProviderDelays;
 
 use bytes::Bytes;
@@ -75,6 +76,7 @@ impl AutoReturn {
     }
 
     pub async fn into_future(mut self) {
+        debug!("AutoReturn::into_future.send_option={:?}", self.send_option);
         match self.send_option {
             EndpointProvidesSendOptions::Block => {
                 let _ = self
@@ -84,12 +86,20 @@ impl AutoReturn {
             }
             EndpointProvidesSendOptions::Force => {
                 while let Some(json) = self.jsons.pop() {
-                    self.channel.force_send(json);
+                    log::trace!("AutoReturn::into_future::Force json={}", json);
+                    self
+                    .channel
+                    .force_send(json);
                 }
             }
             EndpointProvidesSendOptions::IfNotFull => {
                 while let Some(json) = self.jsons.pop() {
-                    if self.channel.send(json).now_or_never().is_none() {
+                    log::trace!("AutoReturn::into_future::IfNotFull json={}", json);
+                    if self
+                    .channel
+                    .send(json)
+                    .now_or_never()
+                    .is_none() {
                         break;
                     }
                 }
@@ -206,6 +216,10 @@ pub struct EndpointBuilder {
     start_stream: Option<Pin<Box<dyn Stream<Item = (Instant, Option<Instant>)> + Send>>>,
 }
 
+fn convert_to_debug<T>(value: &Vec<(String, T)>) -> Vec<String> {
+  value.iter().map(|(key, _)| key.clone().to_string()).collect()
+}
+
 impl EndpointBuilder {
     pub fn new(
         endpoint: config::Endpoint,
@@ -236,6 +250,10 @@ impl EndpointBuilder {
             request_timeout,
             ..
         } = self.endpoint;
+        debug!("EndpointBuilder.build method=\"{}\" url=\"{}\" body=\"{}\" headers=\"{:?}\" no_auto_returns=\"{}\" \
+            max_parallel_requests=\"{:?}\" provides=\"{:?}\" logs=\"{:?}\" on_demand=\"{}\" request_timeout=\"{:?}\"",
+            method.as_str(), url.evaluate_with_star(), body, convert_to_debug(&headers), no_auto_returns,
+            max_parallel_requests, convert_to_debug(&provides), convert_to_debug(&logs), on_demand, request_timeout);
 
         let timeout = request_timeout.unwrap_or(ctx.config.client.request_timeout);
 
@@ -244,6 +262,7 @@ impl EndpointBuilder {
         } else {
             None
         };
+        // Build the actual provider set "outgoing"
         let provides = provides
             .into_iter()
             .map(|(k, v)| {
@@ -280,6 +299,7 @@ impl EndpointBuilder {
             });
             streams.push((true, Box::new(stream)));
         }
+        // Add any loggers to the outgoing providers/loggers
         for (k, v) in logs {
             let tx = ctx
                 .loggers
@@ -614,6 +634,7 @@ impl Endpoint {
         S: Stream<Item = Result<StreamItem, TestError>> + Send + Unpin + 'static,
     {
         let stream = Box::new(stream);
+        // If we have one, replace it, otherwise add (set as 0) it
         match self.stream_collection.get_mut(0) {
             Some((true, s)) => {
                 *s = stream;
@@ -670,6 +691,7 @@ impl Endpoint {
                 _ => None,
             })
             .collect();
+        debug!("into_future method=\"{}\" url=\"{:?}\" request_headers={:?} tags={:?}", method, url, headers, tags);
         let rm = RequestMaker {
             url,
             method,

--- a/src/request/request_maker.rs
+++ b/src/request/request_maker.rs
@@ -17,6 +17,7 @@ use hyper::{
     Client, Method, Request,
 };
 use hyper_tls::HttpsConnector;
+use log::{debug, info};
 use serde_json as json;
 
 use super::{
@@ -199,6 +200,8 @@ impl RequestMaker {
             if content_length > 0 {
                 headers.insert(CONTENT_LENGTH, content_length.into());
             }
+            debug!("final headers={:?}", headers);
+            info!("RequestMaker method=\"{}\" url=\"{}\" request_headers={:?} tags={:?}", method, url.as_str(), headers, tags);
             let mut request_provider = json::json!({});
             let request_obj = request_provider
                 .as_object_mut()

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -14,6 +14,7 @@ use futures::{
     stream, FutureExt, StreamExt,
 };
 use hdrhistogram::Histogram;
+use log::debug;
 use serde::{Deserialize, Serialize};
 use serde_json as json;
 use tokio::{
@@ -716,6 +717,7 @@ pub fn create_try_run_stats_channel(
         let _ = console.send(MsgType::Final(output)).await;
     };
 
+    debug!("create_try_run_stats_channel tokio::spawn stats_receiver_task");
     tokio::spawn(stats_receiver_task);
 
     tx
@@ -888,6 +890,7 @@ pub fn create_stats_channel(
         }
     };
 
+    debug!("create_stats_channel tokio::spawn stats_receiver_task");
     tokio::spawn(stats_receiver_task);
 
     Ok(tx)


### PR DESCRIPTION
- Added logging to the pewpew binary to trace the flow through the components
- Fixed a bug Jon found that we only log one header during a try script rather than all if there are duplicates. Changed the try run to log headers_all rather than headers
-  Changed the try script logger to use stdout instead of stderr
- Fixed the docs for try and run to show the change from 0.5.2 that stats go to stdout
-  Modified the Config WebAssembly (config-wasm) to also return file body paths from the endpoint body
