### PR TITLE
Use clap derive, fixing behavior of `--include` flag.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "956ac1f6381d8d82ab4684768f89c0ea3afe66925ceadb4eeb3fc452ffc55d62"
 dependencies = [
  "clap_builder",
+ "clap_derive",
+ "once_cell",
 ]
 
 [[package]]
@@ -225,6 +227,18 @@ dependencies = [
  "clap_lex",
  "once_cell",
  "terminal_size",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -764,6 +778,12 @@ dependencies = [
  "nom",
  "num-traits",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,6 +1382,7 @@ dependencies = [
  "maplit",
  "mod_interval",
  "native-tls",
+ "once_cell",
  "openssl",
  "rand",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ base64 = "0.21"
 body_reader = { path = "./lib/body_reader" }
 bytes = "1"
 channel = { path = "./lib/channel" }
-clap = { version = "4", features = ["cargo", "std", "help", "usage", "error-context", "wrap_help"], default-features = false }
+clap = { version = "4", features = ["derive", "cargo", "std", "help", "usage", "error-context", "wrap_help"], default-features = false }
 config = { path = "./lib/config" }
 csv = "1"
 ctrlc = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ hyper-tls = "0.5"
 itertools = "0.10"
 mod_interval = { path = "./lib/mod_interval" }
 native-tls = "0.2"
+once_cell = "1.17.1"
 rand = "0.8"
 regex = "1"
 select_any = { path = "./lib/select_any" }

--- a/guide/src/cli.md
+++ b/guide/src/cli.md
@@ -4,16 +4,18 @@ There are two ways that Pewpew can execute: either a full load test or a try run
 <br/><br/>
 
 ```
-USAGE:
-    pewpew <SUBCOMMAND>
+The HTTP load test tool https://familysearch.github.io/pewpew
 
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+Usage: pewpew <COMMANND>
 
-SUBCOMMANDS:
-    run    Runs a full load test
-    try    Runs the specified endpoint(s) a single time for testing purposes
+Commands:
+  run    Runs a full load test
+  try    Runs the specified endpoint(s) a single time for testing purposes
+  help   Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help       Prints help information
+  -V, --version    Prints version information
 ```
 
 As signified in the above help output, there are two subcommands `run` and `try`.
@@ -22,24 +24,22 @@ Here's the output of `pewpew run --help`:
 <br/><br/>
 
 ```
-USAGE:
-    pewpew run <CONFIG>
+Usage: pewpew run [OPTIONS] <CONFIG>
 
-OPTIONS:
-    -h, --help                             Prints help information
-    -f, --output-format <FORMAT>           Formatting for stats printed to stdout [default: human]  [possible values:
-                                           human, json]
-    -d, --results-directory <DIRECTORY>    Directory to store results and logs
-    -t, --start-at <START_AT>              Specify the time the test should start at
-    -o, --stats-file <STATS_FILE>          Specify the filename for the stats file
-    -s, --stats-file-format <FORMAT>       Format for the stats file [default: json]  [possible values: json]
-    -w, --watch                            Watch the config file for changes and update the test accordingly
+Arguments:
+  <CONFIG>  Load test config file to use
 
-ARGS:
-    <CONFIG>    Load test config file to use
-
-ARGS:
-    <CONFIG>    Load test config file to use
+Options:
+  -f, --output-format <FORMAT>         Formatting for stats printed to stdout [default: human]
+                                       [possible values: human, json]
+  -d, --results-directory <DIRECTORY>  Directory to store results and logs
+  -t, --start-at <START_AT>            Specify the time the test should start at
+  -o, --stats-file <STATS_FILE>        Specify the filename for the stats file
+  -s, --stats-file-format <FORMAT>     Format for the stats file [default: json]  [possible values:
+                                       json]
+  -w, --watch                          Watch the config file for changes and update the test
+                                       accordingly
+  -h, --help                           Prints help information
 ```
 
 The `-f`, `--output-format` parameter allows changing the formatting of the stats which are printed to stdout.
@@ -54,22 +54,22 @@ Here's the output of `pewpew try --help`:
 <br/><br/>
 
 ```
-USAGE:
-    pewpew try [OPTIONS] <CONFIG>
+Usage: pewpew try [OPTIONS] <CONFIG>
 
-OPTIONS:
-    -o, --file <FILE>                      Send results to the specified file instead of stdout
-    -f, --format <FORMAT>                  Specify the format for the try run output [default: human]  [possible values:
-                                           human, json]
-    -h, --help                             Prints help information
-    -i, --include <INCLUDE>...             Filter which endpoints are included in the try run. Filters work based on an
-                                           endpoint's tags. Filters are specified in the format "key=value" where "*" is
-                                           a wildcard. Any endpoint matching the filter is included in the test
-    -l, --loggers                          Enable loggers defined in the config file
-    -d, --results-directory <DIRECTORY>    Directory to store logs (if enabled with --loggers)
+Arguments:
+  <CONFIG>  Load test config file to use
 
-ARGS:
-    <CONFIG>    Load test config file to use
+Options:
+  -o, --file <FILE>                    Send results to the specified file instead of stdout
+  -f, --format <FORMAT>                Specify the format for the try run output [default: human]
+                                       [possible values: human, json]
+  -i, --include <INCLUDE>              Filter which endpoints are included in the try run. Filters
+                                       work based on an endpoint's tags. Filters are specified in
+                                       the format "key=value" where "*" is a wildcard. Any
+                                       endpoint matching the filter is included in the test
+  -l, --loggers                        Enable loggers defined in the config file
+  -d, --results-directory <DIRECTORY>  Directory to store logs (if enabled with --loggers)
+  -h, --help                           Prints help information
 ```
 
 A try run will run one or more endpoints a single time and print out the raw HTTP requests and responses to stdout. By default all endpoints are included in the try run. This is useful for testing out a [config file](./config.md) before running a full load test. When the `--include` parameter is used, pewpew will automatically include any other endpoints needed to provide data for the explicitly included endpoints.

--- a/src/bin/pewpew.rs
+++ b/src/bin/pewpew.rs
@@ -132,18 +132,19 @@ mod args {
     #[derive(Clone, Debug, Args)]
     struct TryConfigTmp {
         /// Load test config file to use
+        #[arg(value_name = "CONFIG")]
         config_file: PathBuf,
         /// Send results to the specified file instead of stdout
         #[arg(short = 'o', long)]
         file: Option<String>,
+        /// Specify the format for the try run output
+        #[arg(short, long, default_value_t)]
+        format: TryRunFormat,
         /// Filter which endpoints are included in the try run. Filters work based on an
         /// endpoint's tags. Filters are specified in the format "key=value" where "*" is
         /// a wildcard. Any endpoint matching the filter is included in the test
         #[arg(short = 'i', long = "include", value_parser = TryFilter::from_str, value_name = "INCLUDE")]
         filters: Option<Vec<TryFilter>>,
-        /// Specify the format for the try run output
-        #[arg(short, long, default_value_t)]
-        format: TryRunFormat,
         /// Enable loggers defined in the config file
         #[arg(short = 'l', long = "loggers")]
         loggers_on: bool,

--- a/src/bin/pewpew.rs
+++ b/src/bin/pewpew.rs
@@ -766,12 +766,12 @@ mod tests {
 
     #[test]
     fn cli_try_include() {
-        // FAILS after 1:1 port as a result of new `-i` behavior.
         let cli_config = args::try_parse_from([
             "myprog",
             TRY_COMMAND,
             "-i",
             "_id=0",
+            "-i",
             "_id=1",
             "-f",
             "json",
@@ -802,10 +802,16 @@ mod tests {
 
     #[test]
     fn cli_try_include2() {
-        // FAILS after 1:1 port as a result of new `-i` behavior.
-        let cli_config =
-            args::try_parse_from(["myprog", TRY_COMMAND, YAML_FILE2, "-i", "_id=0", "_id=1"])
-                .unwrap();
+        let cli_config = args::try_parse_from([
+            "myprog",
+            TRY_COMMAND,
+            YAML_FILE2,
+            "-i",
+            "_id=0",
+            "-i",
+            "_id=1",
+        ])
+        .unwrap();
         let ExecConfig::Try(try_config) = cli_config else { panic!() };
 
         assert_eq!(try_config.config_file.to_str().unwrap(), YAML_FILE2);

--- a/src/bin/pewpew.rs
+++ b/src/bin/pewpew.rs
@@ -317,6 +317,9 @@ mod args {
     // Temporaries are for the some properties which requires the values of other properties
     // to evaluate. clap will parse directly into the temporaries, and those, which now
     // have all the values, get converted into the "real" config data.
+    //
+    // Enabling the original structs to be used directly would need a bit of compat breaking, so
+    // see if it can be done for 0.6.0
 
     #[derive(Subcommand, Debug)]
     enum ExecConfigTmp {

--- a/src/bin/pewpew.rs
+++ b/src/bin/pewpew.rs
@@ -7,7 +7,7 @@ use std::{
     time::{Duration, UNIX_EPOCH},
 };
 
-use clap::{builder::ValueParser, crate_version, Arg, ArgMatches, Command};
+use clap::{builder::ValueParser, crate_version, Arg, ArgMatches, Command, Parser};
 use config::duration_from_string;
 use futures::channel::mpsc as futures_channel;
 use log::{debug, info};
@@ -288,6 +288,16 @@ fn get_cli_config(matches: ArgMatches) -> ExecConfig {
     }
 }
 
+#[derive(Debug, Parser)]
+#[command(
+    version = clap::crate_version!(),
+    about = "The HTTP load test tool https://familysearch.github.io/pewpew"
+)]
+struct Args {
+    #[command(subcommand)]
+    command: ExecConfig,
+}
+
 fn main() {
     #[cfg(target_os = "windows")]
     {
@@ -302,7 +312,7 @@ fn main() {
     if atty::isnt(atty::Stream::Stdout) {
         Paint::disable();
     }
-    let matches = get_arg_matcher().get_matches();
+    //let matches = get_arg_matcher().get_matches();
 
     let (ctrl_c_tx, ctrlc_channel) = futures_channel::unbounded();
 
@@ -310,7 +320,9 @@ fn main() {
         let _ = ctrl_c_tx.unbounded_send(());
     });
 
-    let cli_config = get_cli_config(matches);
+    //let cli_config = get_cli_config(matches);
+    let cli_config = Args::parse().command;
+    println!("{:?}", cli_config);
     // For testing, we can only call the logger inits once. They can't be in get_cli_config so we can call it multiple times
     match cli_config {
         ExecConfig::Run(ref run_config) => {

--- a/src/bin/pewpew.rs
+++ b/src/bin/pewpew.rs
@@ -314,7 +314,7 @@ mod args {
         command: ExecConfigTmp,
     }
 
-    // Temporaries are for the some properties which requires the values of other properties
+    // Temporaries are for some properties which requires the values of other properties
     // to evaluate. clap will parse directly into the temporaries, and those, which now
     // have all the values, get converted into the "real" config data.
     //

--- a/src/bin/pewpew.rs
+++ b/src/bin/pewpew.rs
@@ -593,6 +593,32 @@ mod tests {
     }
 
     #[test]
+    fn cli_try_include4() {
+        // Verify that the old way doesn't work.
+        // Correct is `-i x -i y -i z`, not `-i x y z`
+        let cli_config_result = args::try_parse_from([
+            "myprog",
+            TRY_COMMAND,
+            YAML_FILE,
+            "--include",
+            "_id=0",
+            "_id=1",
+        ]);
+        assert!(cli_config_result.is_err());
+        // Ensure that failure is because of missing `--include`
+        let cli_config_result = args::try_parse_from([
+            "myprog",
+            TRY_COMMAND,
+            YAML_FILE,
+            "--include",
+            "_id=0",
+            "--include",
+            "_id=1",
+        ]);
+        assert!(cli_config_result.is_ok());
+    }
+
+    #[test]
     fn cli_try_format_json() {
         let cli_config =
             args::try_parse_from(["myprog", TRY_COMMAND, "-f", "json", YAML_FILE]).unwrap();

--- a/src/bin/pewpew.rs
+++ b/src/bin/pewpew.rs
@@ -841,6 +841,40 @@ mod tests {
     }
 
     #[test]
+    fn cli_try_include3() {
+        let cli_config = args::try_parse_from([
+            "myprog",
+            TRY_COMMAND,
+            "-i",
+            "_id!=0",
+            "-i",
+            "_id!=1",
+            YAML_FILE2,
+        ])
+        .unwrap();
+        let ExecConfig::Try(try_config) = cli_config else { panic!() };
+
+        assert_eq!(try_config.config_file.to_str().unwrap(), YAML_FILE2);
+        assert!(try_config.filters.is_some());
+        let filters = try_config.filters.unwrap();
+        assert_eq!(filters.len(), 2);
+        match &filters[0] {
+            TryFilter::Ne(key, value) => {
+                assert_eq!(key, "_id");
+                assert_eq!(value, "0");
+            }
+            _ => panic!(),
+        }
+        match &filters[1] {
+            TryFilter::Ne(key, value) => {
+                assert_eq!(key, "_id");
+                assert_eq!(value, "1");
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
     fn cli_try_format_json() {
         let cli_config =
             args::try_parse_from(["myprog", TRY_COMMAND, "-f", "json", YAML_FILE]).unwrap();

--- a/src/bin/pewpew.rs
+++ b/src/bin/pewpew.rs
@@ -314,7 +314,7 @@ mod args {
         command: ExecConfigTmp,
     }
 
-    // Temporaries are for some properties which requires the values of other properties
+    // Temporaries are for some properties which require the values of other properties
     // to evaluate. clap will parse directly into the temporaries, and those, which now
     // have all the values, get converted into the "real" config data.
     //

--- a/src/bin/pewpew.rs
+++ b/src/bin/pewpew.rs
@@ -1,292 +1,10 @@
-use std::{
-    convert::TryInto,
-    ffi::OsString,
-    fs::create_dir_all,
-    io,
-    path::PathBuf,
-    time::{Duration, UNIX_EPOCH},
-};
+use std::io;
 
-use clap::{builder::ValueParser, crate_version, Arg, ArgMatches, Command};
-use config::duration_from_string;
 use futures::channel::mpsc as futures_channel;
 use log::{debug, info};
-use pewpew::{
-    create_run, ExecConfig, RunConfig, RunOutputFormat, StatsFileFormat, TryConfig, TryFilter,
-    TryRunFormat,
-};
-use regex::Regex;
+use pewpew::{create_run, ExecConfig, RunOutputFormat, TryRunFormat};
 use tokio::runtime;
 use yansi::Paint;
-
-fn get_filter_reg() -> Regex {
-    Regex::new("^(.*?)(!=|=)(.*)").expect("is a valid regex")
-}
-
-fn parse_duration(arg: &str) -> Result<Duration, config::Error> {
-    duration_from_string(arg.into())
-}
-
-fn parse_filter(arg: &str) -> Result<String, &'static str> {
-    let filter_reg2: Regex = get_filter_reg();
-    if filter_reg2.is_match(arg) {
-        Ok(arg.to_string())
-    } else {
-        Err("include filters must be in the format `tag=value` or `tag!=value`")
-    }
-}
-
-fn get_arg_matcher() -> clap::Command {
-    Command::new("pewpew")
-        .about("The HTTP load test tool https://familysearch.github.io/pewpew")
-        .version(crate_version!())
-        .disable_help_subcommand(true)
-        .infer_subcommands(true)
-        .subcommand_required(true)
-        .arg_required_else_help(true)
-        // .setting(AppSettings::VersionlessSubcommands)
-        .subcommand(Command::new("run")
-            .about("Runs a full load test")
-            // .setting(AppSettings::UnifiedHelpMessage) // Now the default
-            .arg(
-                Arg::new("output-format")
-                    .short('f')
-                    .long("output-format")
-                    .help("Formatting for stats printed to stderr")
-                    .value_name("FORMAT")
-                    .value_parser(["human","json"])
-                    .default_value("human")
-            )
-            .arg(
-                Arg::new("stats-file")
-                    .short('o')
-                    .long("stats-file")
-                    .help("Specify the filename for the stats file")
-                    .value_name("STATS_FILE")
-                    .value_parser(ValueParser::os_string())
-            )
-            .arg(
-                Arg::new("start-at")
-                    .short('t')
-                    .long("start-at")
-                    .help("Specify the time the test should start at")
-                    .value_name("START_AT")
-                    .value_parser(parse_duration)
-            )
-            .arg(
-                Arg::new("results-directory")
-                    .short('d')
-                    .long("results-directory")
-                    .number_of_values(1)
-                    .help("Directory to store results and logs")
-                    .value_name("DIRECTORY")
-                    .value_parser(ValueParser::os_string())
-            )
-            .arg(
-                Arg::new("stats-file-format")
-                    .short('s')
-                    .long("stats-file-format")
-                    .help("Format for the stats file")
-                    .value_name("FORMAT")
-                    .value_parser(["json"])
-                    // .value_parser(["json", "html", "none"])
-                    .default_value("json")
-            )
-            .arg(
-                Arg::new("watch")
-                    .short('w')
-                    .long("watch")
-                    .help("Watch the config file for changes and update the test accordingly")
-                    .action(clap::ArgAction::SetTrue)
-            )
-            .arg(
-                Arg::new("CONFIG")
-                    .help("Load test config file to use")
-                    .required(true)
-                    .value_parser(ValueParser::os_string()),
-            )
-        )
-        .subcommand(Command::new("try")
-            .about("Runs the specified endpoint(s) a single time for testing purposes")
-            // .setting(AppSettings::UnifiedHelpMessage) // Now the default
-            .arg(
-                Arg::new("loggers")
-                    .short('l')
-                    .long("loggers")
-                    .help("Enable loggers defined in the config file")
-                    .action(clap::ArgAction::SetTrue)
-            )
-            .arg(
-                Arg::new("file")
-                    .short('o')
-                    .long("file")
-                    .help("Send results to the specified file instead of stdout")
-                    .value_name("FILE")
-            )
-            .arg(
-                Arg::new("format")
-                    .short('f')
-                    .long("format")
-                    .help("Specify the format for the try run output")
-                    .value_name("FORMAT")
-                    .value_parser(["human","json"])
-                    .default_value("human")
-            )
-            .arg(
-                Arg::new("include")
-                    .short('i')
-                    .long("include")
-                    .long_help(r#"Filter which endpoints are included in the try run. Filters work based on an endpoint's tags. Filters are specified in the format "key=value" where "*" is a wildcard. Any endpoint matching the filter is included in the test"#)
-                    // .multiple_occurrences(true)
-                    // https://github.com/clap-rs/clap/issues/2688
-                    // https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#400---2022-09-28
-                    // There is no option for multiple '-i x -i y -i z' anymore. The only option is '-i x y z'
-                    // Unfortunately this means you can no longer do 'pewpew try -i x y z test.yaml'
-                    // since it will try to parse test.yaml as an include. -i must either be last, or be followed by another - parameter
-                    .num_args(1..)
-                    .value_parser(parse_filter)
-                    .value_name("INCLUDE")
-            )
-            .arg(
-                Arg::new("results-directory")
-                    .short('d')
-                    .long("results-directory")
-                    .number_of_values(1)
-                    .help("Directory to store logs (if enabled with --loggers)")
-                    .value_name("DIRECTORY")
-                    .value_parser(ValueParser::os_string())
-            )
-            .arg(
-                Arg::new("CONFIG")
-                    .help("Load test config file to use")
-                    .required(true)
-                    .value_parser(ValueParser::os_string()),
-            )
-        )
-}
-
-fn get_cli_config(matches: ArgMatches) -> ExecConfig {
-    let filter_reg: Regex = get_filter_reg();
-    if let Some(matches) = matches.subcommand_matches("run") {
-        let config_file: PathBuf = matches
-            .get_one::<OsString>("CONFIG")
-            .expect("should have CONFIG param")
-            // .as_str()
-            .into();
-        let results_dir: Option<PathBuf> =
-            matches
-                .get_one::<OsString>("results-directory")
-                .map(|d: &OsString| {
-                    create_dir_all(d).unwrap();
-                    PathBuf::from(d)
-                });
-        let output_format: RunOutputFormat = TryInto::try_into(
-            matches
-                .get_one::<String>("output-format")
-                .expect("should have output_format cli arg")
-                .as_str(),
-        )
-        .expect("output_format cli arg unrecognized");
-        let stats_file: PathBuf = matches
-            .get_one::<OsString>("stats-file")
-            .map(PathBuf::from)
-            .unwrap_or_else(|| {
-                let start_sec = UNIX_EPOCH
-                    .elapsed()
-                    .map(|d| d.as_secs())
-                    .unwrap_or_default();
-                let test_name = config_file.file_stem().and_then(std::ffi::OsStr::to_str);
-                let file = if let Some(test_name) = test_name {
-                    format!("stats-{test_name}-{start_sec}.json")
-                } else {
-                    format!("stats-{start_sec}.json")
-                };
-                PathBuf::from(file)
-            });
-        let stats_file = if let Some(results_dir) = &results_dir {
-            let mut file = results_dir.clone();
-            file.push(stats_file);
-            file
-        } else {
-            stats_file
-        };
-        let stats_file_format = StatsFileFormat::Json;
-        let watch_config_file = matches.get_flag("watch");
-        let start_at = matches
-            .get_one::<Duration>("start-at")
-            .map(|d| d.to_owned());
-        let run_config = RunConfig {
-            config_file,
-            output_format,
-            results_dir,
-            start_at,
-            stats_file,
-            stats_file_format,
-            watch_config_file,
-        };
-        ExecConfig::Run(run_config)
-    } else if let Some(matches) = matches.subcommand_matches("try") {
-        let config_file: PathBuf = matches
-            .get_one::<OsString>("CONFIG")
-            .expect("should have CONFIG param")
-            .into();
-        let results_dir = matches
-            .get_one::<OsString>("results-directory")
-            .map(|s| s.as_os_str());
-        let loggers_on = matches.get_flag("loggers");
-        let results_dir = match (results_dir, loggers_on) {
-            (Some(d), true) => {
-                create_dir_all(d).unwrap();
-                Some(d.into())
-            }
-            _ => None,
-        };
-        let filters = matches.get_many::<String>("include").map(|v| {
-            v.map(|s| {
-                let s = s.as_str();
-                let captures = filter_reg
-                    .captures(s)
-                    .expect("include cli arg should match regex");
-                let left = captures
-                    .get(1)
-                    .expect("include arg should match regex")
-                    .as_str()
-                    .to_string();
-                let right = captures
-                    .get(3)
-                    .expect("include arg should match regex")
-                    .as_str()
-                    .to_string();
-                let comparator = captures
-                    .get(2)
-                    .expect("include arg should match regex")
-                    .as_str();
-                match comparator {
-                    "=" => TryFilter::Eq(left, right),
-                    "!=" => TryFilter::Ne(left, right),
-                    _ => unreachable!(),
-                }
-            })
-            .collect()
-        });
-        let format: TryRunFormat = matches
-            .get_one::<String>("format")
-            .and_then(|f| f.as_str().try_into().ok())
-            .unwrap_or_default();
-        let file = matches.get_one::<String>("file").map(Into::into);
-        let try_config = TryConfig {
-            config_file,
-            file,
-            filters,
-            format,
-            loggers_on,
-            results_dir,
-        };
-        ExecConfig::Try(try_config)
-    } else {
-        unreachable!();
-    }
-}
 
 mod args {
     use clap::{Args, Parser, Subcommand};
@@ -468,7 +186,6 @@ fn main() {
     if atty::isnt(atty::Stream::Stdout) {
         Paint::disable();
     }
-    //let matches = get_arg_matcher().get_matches();
 
     let (ctrl_c_tx, ctrlc_channel) = futures_channel::unbounded();
 
@@ -476,7 +193,6 @@ fn main() {
         let _ = ctrl_c_tx.unbounded_send(());
     });
 
-    //let cli_config = get_cli_config(matches);
     let cli_config = args::get_cli_config();
     // For testing, we can only call the logger inits once. They can't be in get_cli_config so we can call it multiple times
     match cli_config {
@@ -526,6 +242,8 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
+    use pewpew::{StatsFileFormat, TryFilter};
+    use regex::Regex;
     use std::time::Duration;
 
     use super::*;

--- a/src/bin/pewpew.rs
+++ b/src/bin/pewpew.rs
@@ -538,6 +538,12 @@ mod tests {
     static STATS_FILE: &str = "stats-paths.json";
 
     #[test]
+    fn base_clap_verify() {
+        use clap::CommandFactory;
+        args::ArgsData::command().debug_assert();
+    }
+
+    #[test]
     fn cli_run_simple() {
         let stats_regex = Regex::new(r"^stats-integration-\d+\.json$").unwrap();
         let cli_config: ExecConfig =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,10 +291,13 @@ impl FromStr for TryFilter {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // TODO: make into lazy static
-        let reg = regex::Regex::new("^(.*?)(!=|=)(.*)").expect("is a valid regex");
+        use once_cell::sync::Lazy;
+        use regex::Regex;
 
-        let caps = reg.captures(s).ok_or("failed match")?;
+        static REGEX: Lazy<Regex> =
+            Lazy::new(|| Regex::new("^(.*?)(!=|=)(.*)").expect("is a valid regex"));
+
+        let caps = REGEX.captures(s).ok_or("failed match")?;
         let lhs = caps.get(1).unwrap().as_str().to_owned();
         let cmp = caps.get(2).unwrap().as_str();
         let rhs = caps.get(3).unwrap().as_str().to_owned();


### PR DESCRIPTION
Rewrites the command line argument parsing segment of the `pewpew` cli program; where the `clap` "builder" API was used previously, the "derive" form is now used.

As a part of this rewrite, the intended behavior of the `-i`/`--include` flag for the `try` subcommand was restored. Now, `-i x y z` is not valid, but `-i x -i y -i z` is. This also allows the positional argument for the config file to be placed after the include filters.

- The old, builder-focused, code was removed.
- Tests were rewritten, primarily to read an `ExecConfig` from the new derived parser, but tests that contained `--include _id=0 _id=1` or similar as arguments were rewritten to have `--include _id=0 --include _id=1`
- The examples of `--help` output in the book were also modified to be more in line with actual output.

This rewrite was done in a way that attempts to preserve compatibility in the library crate as much as possible. The temporary structs defined in the `args` module in `pewpew.rs` are for some of the values which require other values to be evaluated, and `clap` derive has each property evaluated independently. These temporaries are built directly from the args, and then with all the values, are used to convert into the config structs defined in `lib.rs`.

A compatibility-breaking change that should be considered for `pewpew` version `0.6.0` would be to rewrite those structs (`RunConfig` and `TryConfig`) in such a way that makes them work better with `clap` derive, but still allows the dependent values to be evaluated later.