### PR TITLE
use IsTerminal trait (Rust 1.70.0), removing (direct) dependency on `atty` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,7 +1357,6 @@ dependencies = [
 name = "pewpew"
 version = "0.5.12"
 dependencies = [
- "atty",
  "base64 0.21.0",
  "body_reader",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ name = "test-server"
 path = "src/bin/test_server.rs"
 
 [dependencies]
-atty = "0.2"
 base64 = "0.21"
 body_reader = { path = "./lib/body_reader" }
 bytes = "1"

--- a/src/bin/pewpew.rs
+++ b/src/bin/pewpew.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::io::{self, IsTerminal};
 
 use futures::channel::mpsc as futures_channel;
 use log::{debug, info};
@@ -180,11 +180,7 @@ fn main() {
             Paint::disable();
         }
     }
-    // TODO: https://rustsec.org/advisories/RUSTSEC-2021-0145
-    // Consider
-    //  - [is-terminal](https://crates.io/crates/is-terminal)
-    //  - std::io::IsTerminal *nightly-only experimental*
-    if atty::isnt(atty::Stream::Stdout) {
+    if !io::stdout().is_terminal() {
         Paint::disable();
     }
 


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2021-0145

This PR only removes the *direct* dependency on `atty`. The `pr.sh` script will still show the advisory warning, as the version of `env_logger` pulled in by `jsonpath_lib` (currently pinned to an older version for compatibility) does itself depend on `atty`.

With this PR, the MSRV will be upped to `Rust 1.70.0`.