### PR TITLE
Scripting updater formatting

### DIFF
--- a/examples/log_csv.yaml
+++ b/examples/log_csv.yaml
@@ -36,7 +36,7 @@ endpoints:
     peak_load: 1hps
     logs:
       csv_data:
-        select: '`${response.body.a},"${response.body.data}",${response.body.test},${response.status},${stats.rtt}`'
+        select: '`${a},"${response.body.data}",${response.body.test},${response.status},${stats.rtt}`'
         where: response.status == 200
       test:
         select: response.status

--- a/examples/random_search.yaml
+++ b/examples/random_search.yaml
@@ -165,7 +165,7 @@ endpoints:
         "hasCountry": ${p:hasCountry},
         ${x:${p:hasCountry} ? '"country": ["' + ${p:country} + '"],' : ""}
         ${x:(${p:hasCountry} == false || ${p:country} == "United States") && ${p:hasState} ? '"state": ["' + ${p:us_state} + '"],' : ""}
-        "fromDate": ${x:${p:hasFromDate} ?  ${p:whenFacetArray}[0]  : null},
+        "fromDate": ${x:${p:hasFromDate} ? ${p:whenFacetArray}[0]  : null},
         "toDate": ${x:${p:hasFromDate} ? ${p:whenFacetArray}[1] : null},
         "name": ${x:${p:hasName} ? stwrap(${p:person}.last_name) : null},
         "gender": ${x:${p:hasGender} ? stwrap(${p:person}.gender) : null},

--- a/lib/config-gen/tests/test.js
+++ b/lib/config-gen/tests/test.js
@@ -12,13 +12,13 @@ const jsonBasic = {
      "linear": {
         "from": "10%",
         "to": "100%",
-        "over": "1m"
+        "over": "1h"
       }
     },{
     "linear": {
       "from": "100%",
       "to": "100%",
-      "over": "1m"
+      "over": "90m"
     }
   }],
   "providers": {
@@ -27,7 +27,7 @@ const jsonBasic = {
   "endpoints": [
       {
         "url": "localhost:${v:port}/${v:token}${p:sequence}",
-        "peak_load": "1hps"
+        "peak_load": "1hpm"
       }
   ],
   "loggers": {
@@ -38,25 +38,25 @@ const jsonBasic = {
 const yamlBasic = `vars:
   port: \${e:PORT}
   token: \${x:random(1, 100)}
-config:
-  client:
-    request_timeout: 60s
-    headers: {}
-    keepalive: 90s
-  general:
-    auto_buffer_start_size: 5
-    bucket_size: 60s
-    log_provider_stats: true
-    watch_transition_time: null
 load_pattern:
 - !linear
   from: 10%
   to: 100%
-  over: 60s
+  over: 1h
 - !linear
   from: 100%
   to: 100%
-  over: 60s
+  over: 90m
+config:
+  client:
+    request_timeout: 1m
+    headers: {}
+    keepalive: 90s
+  general:
+    auto_buffer_start_size: 5
+    bucket_size: 1m
+    log_provider_stats: true
+    watch_transition_time: null
 loggers:
   test:
     query:
@@ -90,7 +90,7 @@ endpoints:
   headers: {}
   body: null
   load_pattern: null
-  peak_load: 1hps
+  peak_load: 1hpm
   provides: {}
   on_demand: false
   logs: {}

--- a/lib/config/src/configv2/common.rs
+++ b/lib/config/src/configv2/common.rs
@@ -82,7 +82,16 @@ impl TryFrom<&str> for Duration {
 
 impl Display for Duration {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}s", self.0.as_secs())
+        let minutes = self.0.as_secs_f64() / 60.0;
+        let hours = minutes / 60.0;
+        // If it rounds to minutes, do it. If it rounds to hours, same
+        if hours.fract() == 0.0 {
+            write!(f, "{}h", hours)
+        } else if minutes.fract() == 0.0 {
+            write!(f, "{}m", minutes)
+        } else {
+            write!(f, "{}s", self.0.as_secs())
+        }
     }
 }
 

--- a/lib/config/src/configv2/endpoints.rs
+++ b/lib/config/src/configv2/endpoints.rs
@@ -278,7 +278,12 @@ pub struct HitsPerMinute(f64);
 
 impl std::fmt::Display for HitsPerMinute {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}hps", self.0 / 60.0)
+        // See if it rounds to hpm and format as such
+        if self.0.fract() == 0.0 {
+            write!(f, "{}hpm", self.0)
+        } else {
+            write!(f, "{}hps", self.0 / 60.0)
+        }
     }
 }
 

--- a/lib/config/src/configv2/load_pattern.rs
+++ b/lib/config/src/configv2/load_pattern.rs
@@ -25,6 +25,7 @@ impl Display for Percent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let value = self.0 * 100.0;
         if value.fract() == 0.0 {
+            // There's no point in writing out 10.000 or 100.000
             write!(f, "{:.0}%", value)
         } else {
             write!(f, "{:.3}%", value)

--- a/lib/config/src/configv2/mod.rs
+++ b/lib/config/src/configv2/mod.rs
@@ -40,10 +40,10 @@ pub struct LoadTest<VD: Bool = True, ED: Bool = True> {
     pub(crate) vars: Vars<ED>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) lib_src: Option<LibSrc>,
-    #[serde(default = "Config::default")]
-    pub config: config::Config<VD>,
     #[serde(bound = "load_pattern::LoadPattern<VD>: serde::de::DeserializeOwned")]
     pub(crate) load_pattern: Option<load_pattern::LoadPattern<VD>>,
+    #[serde(default = "Config::default")]
+    pub config: config::Config<VD>,
     #[serde(default = "BTreeMap::new")]
     pub loggers: BTreeMap<Arc<str>, Logger<VD>>,
     #[serde(default = "BTreeMap::new")]

--- a/src/request/response_handler.rs
+++ b/src/request/response_handler.rs
@@ -87,7 +87,7 @@ impl ResponseHandler {
                             Ok(other) => other,
                             Err(e) => {
                                 if !body_string.is_empty() {
-                                    log::warn!("error converting string {body_string:?} to json ({e}); using original string as fallback");
+                                    log::debug!("error converting string {body_string:?} to json ({e}); using original string as fallback");
                                 }
                                 json::Value::String(body_string.to_owned())
                             }


### PR DESCRIPTION
- [Lowered logging to debug when response can't be parsed as JSON. It was happening on ALL non-json responses](https://github.com/FamilySearch/pewpew/commit/a3cee58cb6d7470df583aecda090ecd4f598e231)
- [Updated formatting to round to hpm for rates or m or h for durations](https://github.com/FamilySearch/pewpew/commit/4607b3a7ff0174293aad7f42ba675245ac33a77d)
- [Removed unneeded space](https://github.com/FamilySearch/pewpew/commit/5c2ca26b87a9710d3a042d934f1190e8a594912a)
- [Updated the example to use a provider](https://github.com/FamilySearch/pewpew/commit/69d7c3efa515d3ae544e232ff934e48a2a33ede8)
- [Changed the order for the config gen to put load_patterns before config](https://github.com/FamilySearch/pewpew/commit/0de06b1dd20b857734e795aa9fbef179a97a7e74)