### PR TITLE
Config updater improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,13 @@ C:\vcpkg> set VCPKGRS_DYNAMIC=1 (or simply set it as your environment variable)
 Changes:
 - Major changes: Javascript scripting!
 - Updated config-wasm to parse legacy and scripting yaml files
+- New binary pewpew-config-updater will attempt to convert legacy config yamls to the new version. If it can't convert the code it will leave in PLACEHOLDERS and TODO
+  - Known issues:
+  - Expressions in vars will not wrap environment variables in the expected `${e:VAR}`
+  - vars in `logs` and `provides` will not have the prepended `_v.` before the var name.
 
 Bugs:
-- Collect returns an array of strings regardless of input type
-- auto-converter removes code templates. Leave in and TODO
+- Collect returns an array of strings regardless of input type. Workaround, use scripting to `.map(parseInt)`.
 - global loggers may not be running in try script
 
 Bug fixes:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Changes:
 
 Bugs:
 - Collect returns an array of strings regardless of input type. Workaround, use scripting to `.map(parseInt)`.
+- Declare expressions that create strings will escape out any json/quotes. No workaround currently.
 - global loggers may not be running in try script
 
 Bug fixes:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Changes:
 Bugs:
 - Collect returns an array of strings regardless of input type. Workaround, use scripting to `.map(parseInt)`.
 - Declare expressions that create strings will escape out any json/quotes. No workaround currently.
+- Vars cannot be decimal point values. Ex `peakLoad: 0.87`. Workaround: `peakLoad: ${x:0.87}`
 - global loggers may not be running in try script
 
 Bug fixes:

--- a/deny.toml
+++ b/deny.toml
@@ -14,7 +14,7 @@ unmaintained = "warn"
 yanked = "warn"
 notice = "warn"
 ignore = [
-    "RUSTSEC-2020-0071",
+    # "RUSTSEC-2020-0071",
 ]
 
 [licenses]

--- a/guide/build-guide.sh
+++ b/guide/build-guide.sh
@@ -42,7 +42,7 @@ wasm-pack build --release -t bundler -d $CFG_GEN_OUTPUT_REACT_DIR --scope fs
 
 # build the results viewer (which includes putting the output into the book's src)
 cd $RESULTS_VIEWER_REACT_DIR
-npm install
+npm ci
 npm run build
 
 # build the book

--- a/guide/serve-guide.sh
+++ b/guide/serve-guide.sh
@@ -42,7 +42,7 @@ wasm-pack build --release -t bundler -d $CFG_GEN_OUTPUT_REACT_DIR --scope fs
 
 # build the results viewer (which includes putting the output into the book's src)
 cd $RESULTS_VIEWER_REACT_DIR
-npm install
+npm ci
 npm run build
 
 # build the book

--- a/lib/config-gen/tests/test.js
+++ b/lib/config-gen/tests/test.js
@@ -66,15 +66,15 @@ loggers:
         timestamp: epoch("ms")
       for_each: []
       where: null
+    limit: null
     to: stdout
     pretty: false
-    limit: null
     kill: false
   test2:
     query: null
+    limit: null
     to: !file out.txt
     pretty: false
-    limit: null
     kill: false
 providers:
   sequence: !list

--- a/lib/config/src/configv1/convert_helper.rs
+++ b/lib/config/src/configv1/convert_helper.rs
@@ -413,8 +413,12 @@ fn map_query(
         let query = match select_temp {
             json::Value::Object(_) => {
                 log::info!("Object query: {select_temp}");
-                Query::<False>::complex_json(format!("{select_temp}").as_str(), for_each, where_clause)
-            },
+                Query::<False>::complex_json(
+                    format!("{select_temp}").as_str(),
+                    for_each,
+                    where_clause,
+                )
+            }
             json::Value::String(s) => Query::simple(s.to_string(), for_each, where_clause),
             _ => Query::simple(format!("{select_temp}"), for_each, where_clause),
         };

--- a/lib/config/src/configv1/convert_helper.rs
+++ b/lib/config/src/configv1/convert_helper.rs
@@ -415,6 +415,7 @@ fn map_query(
                 log::info!("Object query: {select_temp}");
                 Query::<False>::complex_json(format!("{select_temp}").as_str(), for_each, where_clause)
             },
+            json::Value::String(s) => Query::simple(s.to_string(), for_each, where_clause),
             _ => Query::simple(format!("{select_temp}"), for_each, where_clause),
         };
         let query = match query {

--- a/lib/config/src/configv1/convert_helper.rs
+++ b/lib/config/src/configv1/convert_helper.rs
@@ -387,10 +387,7 @@ fn map_query(
     // Attempt to parse the for_each
     let for_each: Vec<String> = for_each
         .iter()
-        .map(|fe| {
-            let fe2 = (fe.inner.to_string(), fe.marker).0;
-            fe2
-        })
+        .map(|fe| (fe.inner.to_string(), fe.marker).0)
         .collect();
 
     // See if we can create a fallback with the where and for_each but without the select

--- a/lib/config/src/configv1/expression_functions.rs
+++ b/lib/config/src/configv1/expression_functions.rs
@@ -28,25 +28,23 @@ fn get_low_high(uniform: String) -> (String, String) {
     // Or Uniform(UniformFloat { low: 1.1, scale: 9.200000000000001 })
     let re_int = Regex::new(r"low: (\d+), range: (\d+),").unwrap();
     let re_float = Regex::new(r"low: ([0-9\.]+), scale: ([0-9\.]+) ").unwrap();
-    match re_int.captures(&uniform.as_str()) {
+    match re_int.captures(uniform.as_str()) {
         Some(caps) => {
             let low = (caps[1]).parse::<i64>();
             let range = (caps[2]).parse::<i64>();
-            if low.is_ok() && range.is_ok() {
-                let low = low.unwrap();
-                let high = range.unwrap() + low;
+            if let (Ok(low), Ok(range)) = (low, range) {
+                let high = range + low;
                 (format!("{low:.0}"), format!("{high:.0}"))
             } else {
                 ((caps[1]).to_owned(), (caps[2]).to_owned())
             }
         }
-        None => match re_float.captures(&uniform.as_str()) {
+        None => match re_float.captures(uniform.as_str()) {
             Some(caps) => {
                 let low = (caps[1]).parse::<f64>();
                 let range = (caps[2]).parse::<f64>();
-                if low.is_ok() && range.is_ok() {
-                    let low = low.unwrap();
-                    let high = range.unwrap() + low;
+                if let (Ok(low), Ok(range)) = (low, range) {
+                    let high = range + low;
                     if low.fract() == 0.0 && high.fract() == 0.0 {
                         (format!("{low:.0}"), format!("{high:.0}"))
                     } else {

--- a/lib/config/src/configv1/expression_functions.rs
+++ b/lib/config/src/configv1/expression_functions.rs
@@ -193,6 +193,12 @@ pub(super) struct Encode {
     encoding: Encoding,
 }
 
+impl std::fmt::Display for Encode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "encode({}, \"{}\")", self.arg, self.encoding)
+    }
+}
+
 impl Encode {
     pub(super) fn new(
         mut args: Vec<ValueOrExpression>,
@@ -258,15 +264,15 @@ impl Encode {
     }
 }
 
-impl std::fmt::Display for Encode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "encode({}, \"{}\")", self.arg, self.encoding)
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct Entries {
     arg: ValueOrExpression,
+}
+
+impl std::fmt::Display for Entries {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "entries({})", self.arg)
+    }
 }
 
 impl Entries {
@@ -387,12 +393,6 @@ impl Entries {
     }
 }
 
-impl std::fmt::Display for Entries {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "entries({})", self.arg)
-    }
-}
-
 // `Epoch` enum is in the shared module
 impl Epoch {
     pub(super) fn new(
@@ -435,6 +435,12 @@ pub(super) struct If {
     first: ValueOrExpression,
     second: ValueOrExpression,
     third: ValueOrExpression,
+}
+
+impl std::fmt::Display for If {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "if({}, {}, {})", self.first, self.second, self.third)
+    }
 }
 
 impl If {
@@ -560,17 +566,21 @@ impl If {
     }
 }
 
-impl std::fmt::Display for If {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "if({}, {}, {})", self.first, self.second, self.third)
-    }
-}
-
 #[derive(Clone, Debug)]
 pub(super) struct Join {
     arg: ValueOrExpression,
     sep: String,
     sep2: Option<String>,
+}
+
+impl std::fmt::Display for Join {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(sep2) = &self.sep2 {
+            write!(f, "join({}, \"{}\", \"{}\")", self.arg, self.sep, sep2)
+        } else {
+            write!(f, "join({}, \"{}\")", self.arg, self.sep)
+        }
+    }
 }
 
 impl Join {
@@ -678,16 +688,6 @@ impl Join {
         self.arg
             .into_stream(providers, no_recoverable_error)
             .map_ok(move |(d, returns)| (Join::evaluate_with_arg(&sep, &sep2, &d), returns))
-    }
-}
-
-impl std::fmt::Display for Join {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(sep2) = &self.sep2 {
-            write!(f, "join({}, \"{}\", \"{}\")", self.arg, self.sep, sep2)
-        } else {
-            write!(f, "join({}, \"{}\")", self.arg, self.sep)
-        }
     }
 }
 
@@ -1303,11 +1303,18 @@ impl std::fmt::Display for Range {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Range::Args(args) => write!(f, "range({}, {})", args.0, args.1),
-            Range::Range(range) => if range.reverse {
-                write!(f, "range({}, {})", range.range.end - 1, range.range.start - 1)
-            } else {
-                write!(f, "range({}, {})", range.range.start, range.range.end)
-            },
+            Range::Range(range) => {
+                if range.reverse {
+                    write!(
+                        f,
+                        "range({}, {})",
+                        range.range.end - 1,
+                        range.range.start - 1
+                    )
+                } else {
+                    write!(f, "range({}, {})", range.range.start, range.range.end)
+                }
+            }
         }
     }
 }
@@ -1521,7 +1528,11 @@ pub(super) struct Replace {
 
 impl std::fmt::Display for Replace {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "replace({}, {}, {})", self.needle, self.haystack, self.replacer)
+        write!(
+            f,
+            "replace({}, {}, {})",
+            self.needle, self.haystack, self.replacer
+        )
     }
 }
 

--- a/lib/config/src/configv1/expression_functions.rs
+++ b/lib/config/src/configv1/expression_functions.rs
@@ -17,7 +17,7 @@ use zip_all::zip_all;
 
 use std::{borrow::Cow, cmp::Ordering, collections::BTreeMap, fmt, iter, sync::Arc, task::Poll};
 
-/// Helper function for converting to new config where we use a Uniform Range.
+/// Helper function for converting to new v2 config where we use a Uniform Range.
 /// Takes a format!("{range:?}") and finds the low an high and returns them as strings
 ///
 /// # Panics
@@ -559,7 +559,7 @@ impl If {
         })
     }
 
-    pub(super) fn to_convert(&self) -> String {
+    pub(super) fn convert_to_v2(&self) -> String {
         format!("({}) ? {} : {}", self.first, self.second, self.third)
     }
 }
@@ -1247,6 +1247,12 @@ impl Random {
         }))
     }
 
+    /// Helper function for converting to new v2 config where we use a Uniform Range.
+    /// Takes a format!("{range:?}") and finds the low an high and returns them as strings
+    ///
+    /// # Panics
+    ///
+    /// Panics if .
     pub(super) fn get_low_high(&self) -> (String, String) {
         let uniform = match self {
             Random::Integer(r) => format!("{:?}", r),
@@ -1255,7 +1261,7 @@ impl Random {
         get_low_high(uniform)
     }
 
-    pub(super) fn to_convert(&self) -> String {
+    pub(super) fn convert_to_v2(&self) -> String {
         let (low, high) = self.get_low_high();
         format!("random({}, {}, ${{p:null}})", low, high)
     }

--- a/lib/config/src/configv1/expression_functions.rs
+++ b/lib/config/src/configv1/expression_functions.rs
@@ -214,6 +214,12 @@ impl Encode {
     }
 }
 
+impl std::fmt::Display for Encode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "encode({}, \"{}\")", self.arg, self.encoding)
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Entries {
     arg: ValueOrExpression,

--- a/lib/config/src/configv1/select_parser.rs
+++ b/lib/config/src/configv1/select_parser.rs
@@ -1049,7 +1049,7 @@ impl std::fmt::Display for Expression {
                 ExpressionLhs::Value(v) => write!(f, "{}", v),
             }
         } else {
-            write!(f, "{}", self)
+            write!(f, "{:?}", self)
         }
     }
 }
@@ -2717,7 +2717,7 @@ pub mod template_convert {
                             lhs: ExpressionLhs::Value(Value::Path(p)),
                             op: None,
                         }) => {
-                            log::warn!("template expression path {0:?} - {1:?}; is_empty: {2:?}", p.start, p.rest, p.rest.is_empty());
+                            log::debug!("template expression path {0:?} - {1:?}; is_empty: {2:?}", p.start, p.rest, p.rest.is_empty());
                             match *p {
                                 Path {
                                     start: PathStart::Ident(s),
@@ -2729,16 +2729,16 @@ pub mod template_convert {
                                     rest,
                                     ..
                                 } if rest.is_empty() => {
-                                    log::warn!("template expression function {f:?}");
+                                    log::debug!("template expression function {f:?}");
                                     if let FunctionCall::Collect(_) = f {
-                                        log::warn!("template expression path {f:?} must be updated manually");
+                                        log::warn!("template expression collect {f:?} must be updated manually");
                                         Segment::Placeholder
                                     } else {
                                         Segment::SingleExpression(f.to_convert())
                                     }
                                 },
                                 other => {
-                                    log::warn!("template expression path {other:?} must be updated manually");
+                                    log::warn!("template expression path {other} must be updated manually");
                                     Segment::Placeholder
                                 }
                             }
@@ -2837,8 +2837,8 @@ pub mod template_convert {
                 ("${epoch(\"ms\")}", "epoch(\"ms\")"),
                 ("${if(foo, foo, bar)}", "(foo) ? foo : bar"),
                 (
-                    "${if(match(foo, \"test\"), foo, bar)}",
-                    "(match(foo, \"test\")) ? foo : bar",
+                    "${if(match(foo, \"test\") != null, foo, bar)}",
+                    "(match(foo, \"test\") != null) ? foo : bar",
                 ),
                 ("${join(foo, \",\")}", "join(foo, \",\")"),
                 ("${join(foo, \":\", \"\\n\")}", "join(foo, \":\", \"\\n\")"),

--- a/lib/config/src/configv1/select_parser.rs
+++ b/lib/config/src/configv1/select_parser.rs
@@ -211,14 +211,14 @@ impl FunctionCall {
             FunctionCall::Encode(e) => format!("{e}"),
             FunctionCall::Entries(e) => format!("{e}"),
             FunctionCall::Epoch(e) => format!("{e}"),
-            FunctionCall::If(i) => format!("{}", i.to_convert()),
+            FunctionCall::If(i) => i.to_convert(),
             FunctionCall::Join(j) => format!("{j}"),
             FunctionCall::JsonPath(j) => format!("{j}"),
             FunctionCall::Match(m) => format!("{m}"),
             FunctionCall::MinMax(m) => format!("{m}"),
             FunctionCall::Pad(p) => format!("{p}"),
             FunctionCall::Range(r) => format!("{r}"),
-            FunctionCall::Random(r) => format!("{}", r.to_convert()),
+            FunctionCall::Random(r) => r.to_convert(),
             FunctionCall::Repeat(r) => format!("{r}"),
             FunctionCall::Replace(r) => format!("{r}"),
             FunctionCall::ParseNum(p) => format!("{p}"),
@@ -1327,7 +1327,7 @@ pub struct Template {
 impl std::fmt::Display for Template {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Empty strings get turned into empty Templates with no pieces
-        if self.pieces.len() == 0 {
+        if self.pieces.is_empty() {
             write!(f, "\"\"")
         } else {
             let pieces: Vec<String> = self

--- a/lib/config/src/configv1/select_parser.rs
+++ b/lib/config/src/configv1/select_parser.rs
@@ -471,6 +471,23 @@ pub struct Path {
     pub(super) marker: Marker,
 }
 
+impl std::fmt::Display for Path {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.rest.is_empty() {
+            write!(f, "{}", self.start)
+        } else {
+            let rest: Vec<String> = self
+                .rest
+                .clone()
+                .into_iter()
+                .map(|piece| format!("{piece}"))
+                .collect();
+            let rest = rest.join(".");
+            write!(f, "{}.{}", self.start, rest)
+        }
+    }
+}
+
 impl Path {
     fn evaluate<'a, 'b: 'a>(
         &'b self,
@@ -765,12 +782,8 @@ impl std::fmt::Display for Value {
                     }
                 }
             }
-            Self::Json(j) => write!(
-                f,
-                "{}",
-                serde_json::to_string(j).unwrap_or(format!("{j:?}"))
-            ),
-            Self::Template(t) => write!(f, "{:?}", t),
+            Self::Json(j) => write!(f, "{j}"),
+            Self::Template(t) => write!(f, "{}", t),
         }
     }
 }
@@ -904,6 +917,16 @@ pub(super) enum PathStart {
     FunctionCall(FunctionCall),
     Ident(String),
     Value(json::Value),
+}
+
+impl std::fmt::Display for PathStart {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self {
+            PathStart::Ident(i) => write!(f, "{i}"),
+            PathStart::FunctionCall(func) => write!(f, "{}", &func.to_convert()),
+            PathStart::Value(v) => write!(f, "{v}"),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1261,11 +1284,32 @@ enum TemplatePiece {
     NotExpression(String),
 }
 
+impl std::fmt::Display for TemplatePiece {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TemplatePiece::Expression(x) => write!(f, "{x}"),
+            TemplatePiece::NotExpression(s) => write!(f, "{s}"),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Template {
     pieces: Vec<TemplatePiece>,
     size_hint: usize,
     no_recoverable_error: bool,
+}
+
+impl std::fmt::Display for Template {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let pieces: Vec<String> = self
+            .pieces
+            .clone()
+            .into_iter()
+            .map(|piece| format!("{piece}"))
+            .collect();
+        write!(f, "{}", pieces.join(""))
+    }
 }
 
 impl Template {

--- a/lib/config/src/configv1/select_parser.rs
+++ b/lib/config/src/configv1/select_parser.rs
@@ -867,7 +867,7 @@ impl Value {
 
 #[derive(Clone, Debug)]
 pub(super) enum PathSegment {
-    Number(usize), // [0]
+    Number(usize),  // [0]
     String(String), // like .body on response.body
     Template(Arc<Template>),
 }

--- a/lib/config/src/configv1/select_parser.rs
+++ b/lib/config/src/configv1/select_parser.rs
@@ -204,21 +204,21 @@ impl FunctionCall {
         Ok(r)
     }
 
-    fn to_convert(&self) -> String {
+    fn convert_to_v2(&self) -> String {
         debug!("FunctionCall::evaluate function=\"{:?}\"", self);
         match self {
             FunctionCall::Collect(c) => format!("{c:?}"),
             FunctionCall::Encode(e) => format!("{e}"),
             FunctionCall::Entries(e) => format!("{e}"),
             FunctionCall::Epoch(e) => format!("{e}"),
-            FunctionCall::If(i) => i.to_convert(),
+            FunctionCall::If(i) => i.convert_to_v2(),
             FunctionCall::Join(j) => format!("{j}"),
             FunctionCall::JsonPath(j) => format!("{j}"),
             FunctionCall::Match(m) => format!("{m}"),
             FunctionCall::MinMax(m) => format!("{m}"),
             FunctionCall::Pad(p) => format!("{p}"),
             FunctionCall::Range(r) => format!("{r}"),
-            FunctionCall::Random(r) => r.to_convert(),
+            FunctionCall::Random(r) => r.convert_to_v2(),
             FunctionCall::Repeat(r) => format!("{r}"),
             FunctionCall::Replace(r) => format!("{r}"),
             FunctionCall::ParseNum(p) => format!("{p}"),
@@ -762,7 +762,7 @@ impl std::fmt::Display for Value {
                 if p.rest.is_empty() {
                     match &p.start {
                         PathStart::Ident(i) => write!(f, "{i}"),
-                        PathStart::FunctionCall(func) => write!(f, "{}", &func.to_convert()),
+                        PathStart::FunctionCall(func) => write!(f, "{}", &func.convert_to_v2()),
                         PathStart::Value(v) => write!(f, "{v}"),
                     }
                 } else {
@@ -776,7 +776,7 @@ impl std::fmt::Display for Value {
                     match &p.start {
                         PathStart::Ident(i) => write!(f, "{i}.{rest}"),
                         PathStart::FunctionCall(func) => {
-                            write!(f, "{}.{}", &func.to_convert(), rest)
+                            write!(f, "{}.{}", &func.convert_to_v2(), rest)
                         }
                         PathStart::Value(v) => write!(f, "{v}.{rest}"),
                     }
@@ -867,7 +867,7 @@ impl Value {
 
 #[derive(Clone, Debug)]
 pub(super) enum PathSegment {
-    Number(usize),  // [0] ?
+    Number(usize), // [0]
     String(String), // like .body on response.body
     Template(Arc<Template>),
 }
@@ -875,7 +875,7 @@ pub(super) enum PathSegment {
 impl std::fmt::Display for PathSegment {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Number(n) => write!(f, "[\"{n}\"]"),
+            Self::Number(n) => write!(f, "[{n}]"), // [0]
             Self::String(s) => write!(f, "{s}"),
             Self::Template(t) => write!(f, "{t}"),
         }
@@ -923,7 +923,7 @@ impl std::fmt::Display for PathStart {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self {
             PathStart::Ident(i) => write!(f, "{i}"),
-            PathStart::FunctionCall(func) => write!(f, "{}", &func.to_convert()),
+            PathStart::FunctionCall(func) => write!(f, "{}", &func.convert_to_v2()),
             PathStart::Value(v) => write!(f, "{v}"),
         }
     }
@@ -2793,7 +2793,7 @@ pub mod template_convert {
                                             log::warn!("template expression collect {f:?} must be updated manually");
                                             Segment::Placeholder
                                         } else {
-                                            Segment::SingleExpression(f.to_convert())
+                                            Segment::SingleExpression(f.convert_to_v2())
                                         };
                                         if rest.is_empty() {
                                             segment

--- a/lib/config/src/configv2/loggers.rs
+++ b/lib/config/src/configv2/loggers.rs
@@ -8,10 +8,10 @@ use serde::Deserialize;
 #[serde(deny_unknown_fields)]
 pub struct Logger<VD: Bool = True> {
     pub query: Option<super::query::Query<VD>>,
+    pub limit: Option<u64>,
     pub to: LogTo<VD>,
     #[serde(default)]
     pub pretty: bool,
-    pub limit: Option<u64>,
     #[serde(default)]
     pub kill: bool,
 }

--- a/lib/config/src/configv2/query.rs
+++ b/lib/config/src/configv2/query.rs
@@ -101,15 +101,27 @@ impl<VD: Bool> Query<VD> {
     ///
     /// The json defines the structure of the select, where any terminal string value is an
     /// expression to evaluate.
-    pub fn from_json(json: &str) -> Result<Self, QueryGenError> {
+    pub fn complex_json(
+        json: &str,
+        for_each: Vec<String>,
+        r#where: Option<String>,
+    ) -> Result<Self, QueryGenError> {
         let structure: SelectTmp = serde_json::from_str(json)?;
 
         QueryTmp {
             select: structure,
-            for_each: vec![],
-            r#where: None,
+            for_each,
+            r#where,
         }
         .try_into()
+    }
+
+    /// Create a query from a JSON string.
+    ///
+    /// The json defines the structure of the select, where any terminal string value is an
+    /// expression to evaluate.
+    pub fn from_json(json: &str) -> Result<Self, QueryGenError> {
+        Query::complex_json(json, vec![], None)
     }
 }
 

--- a/lib/config/src/configv2/templating.rs
+++ b/lib/config/src/configv2/templating.rs
@@ -479,12 +479,9 @@ impl<T: TemplateType> TemplatedString<T> {
                         _ => Err(crate::convert::TemplateSegmentError(s)),
                     }
                 }
-                template_convert::Segment::SingleExpression(x) => Ok(Segment::Expr(
-                    vec![Segment::Raw(
-                        x,
-                    )],
-                    True,
-                )),
+                template_convert::Segment::SingleExpression(x) => {
+                    Ok(Segment::Expr(vec![Segment::Raw(x)], True))
+                }
                 template_convert::Segment::Placeholder => Ok(Segment::Expr(
                     vec![Segment::Raw(
                         "PLACEHOLDER__PLEASE_UPDATE_MANUALLY".to_owned(),

--- a/lib/config/src/configv2/templating.rs
+++ b/lib/config/src/configv2/templating.rs
@@ -479,6 +479,12 @@ impl<T: TemplateType> TemplatedString<T> {
                         _ => Err(crate::convert::TemplateSegmentError(s)),
                     }
                 }
+                template_convert::Segment::SingleExpression(x) => Ok(Segment::Expr(
+                    vec![Segment::Raw(
+                        x,
+                    )],
+                    True,
+                )),
                 template_convert::Segment::Placeholder => Ok(Segment::Expr(
                     vec![Segment::Raw(
                         "PLACEHOLDER__PLEASE_UPDATE_MANUALLY".to_owned(),

--- a/lib/config/src/shared.rs
+++ b/lib/config/src/shared.rs
@@ -119,3 +119,14 @@ impl FromStr for Epoch {
         }
     }
 }
+
+impl std::fmt::Display for Epoch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Seconds => write!(f, "epoch(\"s\")"),
+            Self::Milliseconds => write!(f, "epoch(\"ms\")"),
+            Self::Microseconds => write!(f, "epoch(\"mu\")"),
+            Self::Nanoseconds => write!(f, "epoch(\"ns\")"),
+        }
+    }
+}

--- a/lib/config/src/shared/encode.rs
+++ b/lib/config/src/shared/encode.rs
@@ -105,3 +105,17 @@ impl FromStr for Encoding {
         }
     }
 }
+
+impl std::fmt::Display for Encoding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Base64 => write!(f, "base64"),
+            Self::PercentSimple => write!(f, "percent-simple"),
+            Self::PercentQuery => write!(f, "percent-query"),
+            Self::Percent => write!(f, "percent"),
+            Self::PercentPath => write!(f, "percent-path"),
+            Self::PercentUserinfo => write!(f, "percent-userinfo"),
+            Self::NonAlphanumeric => write!(f, "non-alphanumeric"),
+        }
+    }
+}

--- a/pewpew-config-updater/README.md
+++ b/pewpew-config-updater/README.md
@@ -3,3 +3,8 @@ cli tool to partially automate conversion from `0.5.x` pewpew YAML config files 
 Expression segments (queries and some templating sections) will need to be updated manually.
 
 setting `RUST_LOG` to at least `warn` is recommended, as log warnings can help indicate what needs to be updated manually
+
+
+Known issues:
+- Expressions in vars will not wrap environment variables in the expected `${e:VAR}`
+- vars in `logs` and `provides` will not have the prepended `_v.` before the var name.


### PR DESCRIPTION
- Major improvements to the pewpew-config-updater. It will now do everything it can to try and leave the old expressions in and attempt to convert them over
  - Known issues:
  - Expressions in vars will not wrap environment variables in the expected `${e:VAR}`
  - vars in `logs` and `provides` will not have the prepended `_v.` before the var name.
- Changed the order of `limit` in loggers
- Removed cargo deny ignore now that the dependency is removed
