### PR TITLE
Split the skipBody try parameter into separate request/response skip

### DIFF
--- a/guide/src/cli.md
+++ b/guide/src/cli.md
@@ -14,11 +14,8 @@ Commands:
   help   Print this message or the help of the given subcommand(s)
 
 Options:
-  -h, --help              Prints help information
-  -V, --version           Prints version information
-  -l, --loggers           Enable loggers defined in the config file
-  -d, --results-directory Directory to store logs (if enabled with --loggers)
-  -k, --skipBody          Skips request and reponse body from output (try command)
+  -h, --help       Prints help information
+  -V, --version    Prints version information
 ```
 
 As signified in the above help output, there are two subcommands `run` and `try`.
@@ -72,7 +69,8 @@ Options:
                                        endpoint matching the filter is included in the test
   -l, --loggers                        Enable loggers defined in the config file
   -d, --results-directory <DIRECTORY>  Directory to store logs (if enabled with --loggers)
-  -k, --skipBody                       Skips request and reponse body from output (try command)
+  -k, --skip-response-body             Skips reponse body from output (try command)
+  -K, --skip-request-body              Skips request body from output (try command)
   -h, --help                           Prints help information
 ```
 
@@ -84,7 +82,9 @@ The `-l`, `--loggers` flag specifies that any loggers defined in the config file
 
 The `-d`, `--results-directory` parameter will store any log files (if the `--loggers` flag is used) in the specified directory. If the directory does not exist it is created.
 
-The `-k`, `--skipBody` parameter ensures that during a Try run, the request and response bodies aren't displayed. This can be particularly useful for debugging requests or responses when the body is not crucial for the debugging process.
+The `-k`, `--skip-response-body` parameter ensures that during a Try run, the response bodies aren't displayed. This can be particularly useful for debugging responses when the body is very long and not crucial for the debugging process.
+
+The `-K`, `--skip-request-body` parameter ensures that during a Try run, the request bodies aren't displayed. This can be particularly useful for debugging requests when the body is very long and not crucial for the debugging process.
 <br/><br/>
 
 In both the `run` and `try` subcommands a [config file](./config.md) is required.

--- a/src/bin/pewpew.rs
+++ b/src/bin/pewpew.rs
@@ -518,13 +518,9 @@ mod tests {
 
     #[test]
     fn cli_try_skip_response_body() {
-        let cli_config = args::try_parse_from([
-            "myprog",
-            TRY_COMMAND,
-            "--skip-response-body",
-            YAML_FILE,
-        ])
-        .unwrap();
+        let cli_config =
+            args::try_parse_from(["myprog", TRY_COMMAND, "--skip-response-body", YAML_FILE])
+                .unwrap();
         let ExecConfig::Try(try_config) = cli_config else {
             panic!()
         };
@@ -535,13 +531,9 @@ mod tests {
 
     #[test]
     fn cli_try_request_body() {
-        let cli_config = args::try_parse_from([
-            "myprog",
-            TRY_COMMAND,
-            "--skip-request-body",
-            YAML_FILE,
-        ])
-        .unwrap();
+        let cli_config =
+            args::try_parse_from(["myprog", TRY_COMMAND, "--skip-request-body", YAML_FILE])
+                .unwrap();
         let ExecConfig::Try(try_config) = cli_config else {
             panic!()
         };

--- a/src/bin/pewpew.rs
+++ b/src/bin/pewpew.rs
@@ -151,15 +151,19 @@ mod args {
         /// Directory to store logs (if enabled with --loggers)
         #[arg(short = 'd', long = "results-directory", value_name = "DIRECTORY")]
         results_dir: Option<PathBuf>,
-        /// Skips request and reponse body from output
-        #[arg(short = 'k', long = "skipBody")]
-        skip_body_on: bool,
+        /// Skips reponse body from output
+        #[arg(short = 'k', long = "skip-response-body")]
+        skip_response_body_on: bool,
+        /// Skips request body from output
+        #[arg(short = 'K', long = "skip-request-body")]
+        skip_request_body_on: bool,
     }
 
     impl From<TryConfigTmp> for TryConfig {
         fn from(value: TryConfigTmp) -> Self {
             let loggers_on = value.loggers_on;
-            let skip_body_on = value.skip_body_on;
+            let skip_response_body_on = value.skip_response_body_on;
+            let skip_request_body_on = value.skip_request_body_on;
             let results_dir = value.results_dir.filter(|_| loggers_on);
             if let Some(d) = &results_dir {
                 create_dir_all(d).unwrap();
@@ -172,7 +176,8 @@ mod args {
                 filters: value.filters,
                 file: value.file,
                 format: value.format,
-                skip_body_on,
+                skip_response_body_on,
+                skip_request_body_on,
             }
         }
     }
@@ -420,7 +425,8 @@ mod tests {
         assert!(try_config.filters.is_none());
         assert!(matches!(try_config.format, TryRunFormat::Human));
         assert!(!try_config.loggers_on);
-        assert!(!try_config.skip_body_on);
+        assert!(!try_config.skip_response_body_on);
+        assert!(!try_config.skip_request_body_on);
         assert!(try_config.results_dir.is_none());
     }
 
@@ -437,6 +443,7 @@ mod tests {
             "_id=0",
             "-l",
             "-k",
+            "-K",
             "-o",
             STATS_FILE,
             YAML_FILE,
@@ -460,7 +467,8 @@ mod tests {
         }
         assert!(matches!(try_config.format, TryRunFormat::Json));
         assert!(try_config.loggers_on);
-        assert!(try_config.skip_body_on);
+        assert!(try_config.skip_response_body_on);
+        assert!(try_config.skip_request_body_on);
         assert!(try_config.results_dir.is_some());
         assert_eq!(try_config.results_dir.unwrap().to_str().unwrap(), TEST_DIR);
     }
@@ -477,7 +485,8 @@ mod tests {
             "--include",
             "_id=0",
             "--loggers",
-            "--skipBody",
+            "--skip-response-body",
+            "--skip-request-body",
             "--file",
             STATS_FILE,
             YAML_FILE,
@@ -501,9 +510,44 @@ mod tests {
         }
         assert!(matches!(try_config.format, TryRunFormat::Json));
         assert!(try_config.loggers_on);
-        assert!(try_config.skip_body_on);
+        assert!(try_config.skip_response_body_on);
+        assert!(try_config.skip_request_body_on);
         assert!(try_config.results_dir.is_some());
         assert_eq!(try_config.results_dir.unwrap().to_str().unwrap(), TEST_DIR);
+    }
+
+    #[test]
+    fn cli_try_skip_response_body() {
+        let cli_config = args::try_parse_from([
+            "myprog",
+            TRY_COMMAND,
+            "--skip-response-body",
+            YAML_FILE,
+        ])
+        .unwrap();
+        let ExecConfig::Try(try_config) = cli_config else {
+            panic!()
+        };
+        assert_eq!(try_config.config_file.to_str().unwrap(), YAML_FILE);
+        assert!(try_config.skip_response_body_on);
+        assert!(!try_config.skip_request_body_on);
+    }
+
+    #[test]
+    fn cli_try_request_body() {
+        let cli_config = args::try_parse_from([
+            "myprog",
+            TRY_COMMAND,
+            "--skip-request-body",
+            YAML_FILE,
+        ])
+        .unwrap();
+        let ExecConfig::Try(try_config) = cli_config else {
+            panic!()
+        };
+        assert_eq!(try_config.config_file.to_str().unwrap(), YAML_FILE);
+        assert!(!try_config.skip_response_body_on);
+        assert!(try_config.skip_request_body_on);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,9 +335,12 @@ pub struct TryConfig {
     /// Directory to store logs (if enabled with --loggers)
     #[arg(short = 'd', long = "results-directory", value_name = "DIRECTORY")]
     pub results_dir: Option<PathBuf>,
-    /// Skips request and reponse body from output (try command)
-    #[arg(short = 's', long = "skipBody")]
-    pub skip_body_on: bool,
+    /// Skips reponse body from output
+    #[arg(short = 'k', long = "skip-response-body")]
+    pub skip_response_body_on: bool,
+    /// Skips request body from output
+    #[arg(short = 'K', long = "skip-request-body")]
+    pub skip_request_body_on: bool,
 }
 
 impl fmt::Display for TryConfig {
@@ -848,14 +851,14 @@ fn create_try_run_future(
     debug!("create_try_run_future start");
     // create a logger for the try run
     // request.headers only logs single Accept Headers due to JSON requirements. Use headers_all instead
-    let request_body_template = if try_config.skip_body_on {
+    let request_body_template = if try_config.skip_request_body_on {
         ""
     } else if matches!(try_config.format, TryRunFormat::Human) {
         "\n${if(request.body != '', '${request.body}', '')}\n\n"
     } else {
         r#""body": "request.body""#
     };
-    let response_body_template = if try_config.skip_body_on {
+    let response_body_template = if try_config.skip_response_body_on {
         ""
     } else if matches!(try_config.format, TryRunFormat::Human) {
         "\n${if(response.body != '', '${response.body}', '')}\n\n"


### PR DESCRIPTION
- `-k`/`--skip-response-body` will only skip the response body
- `-K`/`--skip-request-body` will only skip the request body
- `-k -K` will skip BOTH request and response body