### PR TITLE
Retain tests longer

### DIFF
--- a/agent/createtest/pewpewtest.spec.ts
+++ b/agent/createtest/pewpewtest.spec.ts
@@ -11,6 +11,7 @@ import {
   TestStatus,
   TestStatusMessage,
   log,
+  logger,
   s3,
   sqs,
   util
@@ -147,11 +148,21 @@ describe("PewPewTest Create Test", () => {
             // Validate S3
           const filename: string = basename(test!.getResultsFile()!);
           const result = await s3.getObject(`${ppaasTestId!.s3Folder}/${filename}`);
-            expect(result).to.not.equal(undefined);
-            expect(result.ContentType).to.equal("application/json");
-            done();
-      })
-      .catch((error) => {
+          expect(result, "result").to.not.equal(undefined);
+          expect(result.ContentType, "result.ContentType").to.equal("application/json");
+          const [tagKeyExtra, tagValueExtra]: [string, string] = s3.defaultTestExtraFileTags().entries().next().value;
+          const stdoutFilename = logger.pewpewStdOutFilename(ppaasTestId!.testId);
+          const stderrFilename = logger.pewpewStdErrFilename(ppaasTestId!.testId);
+          const stdouttags = await s3.getTags({ s3Folder: ppaasTestId!.s3Folder, filename: stdoutFilename });
+          expect(stdouttags, "stdouttags").to.not.equal(undefined);
+          expect(stdouttags!.size, "stdouttags.size").to.be.greaterThan(0);
+          expect(stdouttags!.get(tagKeyExtra), `stdouttags!.get("${tagKeyExtra}")`).to.equal(tagValueExtra);
+          const stderrtags = await s3.getTags({ s3Folder: ppaasTestId!.s3Folder, filename: stderrFilename });
+          expect(stderrtags, "stderrtags").to.not.equal(undefined);
+          expect(stderrtags!.size, "stderrtags.size").to.be.greaterThan(0);
+          expect(stderrtags!.get(tagKeyExtra), `stderrtags!.get("${tagKeyExtra}")`).to.equal(tagValueExtra);
+          done();
+      }).catch((error) => {
         done(error);
       });
     });

--- a/agent/src/pewpewtest.ts
+++ b/agent/src/pewpewtest.ts
@@ -15,6 +15,7 @@ import {
   ec2,
   log,
   logger,
+  s3,
   sqs,
   util
 } from "@fs/ppaas-common";
@@ -418,13 +419,15 @@ export class PewPewTest {
       this.pewpewStdOutS3File = new PpaasS3File({
         filename: logger.pewpewStdOutFilename(this.testMessage.testId),
         s3Folder,
-        localDirectory: logConfig.LogFileLocation
+        localDirectory: logConfig.LogFileLocation,
+        tags: s3.defaultTestExtraFileTags()
       });
       this.log(`pewpewStdOutFilename = ${this.pewpewStdOutS3File.localFilePath}`, LogLevel.DEBUG);
       this.pewpewStdErrS3File =  new PpaasS3File({
         filename: logger.pewpewStdErrFilename(this.testMessage.testId),
         s3Folder,
-        localDirectory: logConfig.LogFileLocation
+        localDirectory: logConfig.LogFileLocation,
+        tags: s3.defaultTestExtraFileTags()
       });
       this.log(`pewpewStdErrS3File = ${this.pewpewStdErrS3File.localFilePath}`, LogLevel.DEBUG);
 
@@ -734,7 +737,8 @@ export class PewPewTest {
                 const foundS3File: PpaasS3File = new PpaasS3File({
                   filename: foundFile,
                   s3Folder: this.testMessage.s3Folder,
-                  localDirectory: this.localPath
+                  localDirectory: this.localPath,
+                  tags: s3.defaultTestExtraFileTags()
                 });
                 yamlCreatedFiles.set(foundFile, foundS3File);
               }

--- a/common/src/util/s3.ts
+++ b/common/src/util/s3.ts
@@ -56,10 +56,14 @@ export const config: { s3Client: S3Client } = {
  * has tags passed in of "key2=value3" then only key1=value1 would be added. WARNING: Is only initialized after s3.init() called.
  */
 export const ADDITIONAL_TAGS_ON_ALL = new Map<string, string>();
-// Don't export so that the original can't be modified
+// Don't export so that the original can't be modified,
+// we'll return a new copy of the Map each time so the original can't be modified
 const TEST_FILE_TAGS_INTERNAL = new Map<string, string>([["test", "true"]]);
-/** Returns a new copy of the Map each time so the original can't be modified */
+const TEST_EXTRA_FILE_TAGS_INTERNAL = new Map<string, string>([["test", "false"]]);
+/** Default tags on all test files (yaml, results, status) from the tests */
 export const defaultTestFileTags = (): Map<string, string> => new Map(TEST_FILE_TAGS_INTERNAL);
+/** Default tags on all extra files from the tests */
+export const defaultTestExtraFileTags = (): Map<string, string> => new Map(TEST_EXTRA_FILE_TAGS_INTERNAL);
 
 /**
  * Initializes the S3 object using environment variables. Runs later so it doesn't throw on start-up

--- a/controller/integration/testmanager.spec.ts
+++ b/controller/integration/testmanager.spec.ts
@@ -25,12 +25,12 @@ import {
   s3
 } from "@fs/ppaas-common";
 import { TestManager, defaultRecurringFileTags} from "../pages/api/util/testmanager";
+import { isYamlFile, latestPewPewVersion } from "../pages/api/util/clientutil";
 import { EventInput } from "@fullcalendar/core";
 import { PpaasEncryptEnvironmentFile } from "../pages/api/util/ppaasencryptenvfile";
 import { TestScheduler } from "../pages/api/util/testscheduler";
 import { expect } from "chai";
 import { getPewPewVersionsInS3 } from "../pages/api/util/pewpew";
-import { latestPewPewVersion } from "../pages/api/util/clientutil";
 import path from "path";
 
 logger.config.LogFileName = "ppaas-controller";
@@ -183,10 +183,15 @@ describe("TestManager Integration", () => {
           expect(s3Files.length, "s3Files.length").to.equal(3);
           // Check that the test=true tag is added
           const [tagKey, tagValue]: [string, string] = s3.defaultTestFileTags().entries().next().value;
+          const [tagKeyExtra, tagValueExtra]: [string, string] = s3.defaultTestExtraFileTags().entries().next().value;
           expect(typeof tagKey, "typeof tagKey").to.equal("string");
           for (const s3File of s3Files) {
             expect(s3File.tags, "s3File.tags").to.not.equal(undefined);
-            expect(s3File.tags?.get(tagKey), `${s3File.filename}.tags?.get("${tagKey}")`).to.equal(tagValue);
+            if (isYamlFile(s3File.filename) || s3File.filename.endsWith(".info")) {
+              expect(s3File.tags?.get(tagKey), `${s3File.filename}.tags?.get("${tagKey}")`).to.equal(tagValue);
+            } else {
+              expect(s3File.tags?.get(tagKeyExtra), `${s3File.filename}.tags?.get("${tagKeyExtra}")`).to.equal(tagValueExtra);
+            }
           }
           done();
         }).catch((error) => {
@@ -510,10 +515,15 @@ describe("TestManager Integration", () => {
           expect(s3Files.length, "s3Files.length").to.equal(5);
           // Check that the test=true tag is added
           const [tagKey, tagValue]: [string, string] = s3.defaultTestFileTags().entries().next().value;
+          const [tagKeyExtra, tagValueExtra]: [string, string] = s3.defaultTestExtraFileTags().entries().next().value;
           expect(typeof tagKey, "typeof tagKey").to.equal("string");
           for (const s3File of s3Files) {
             expect(s3File.tags, "s3File.tags").to.not.equal(undefined);
-            expect(s3File.tags?.get(tagKey), `${s3File.filename}.tags?.get("${tagKey}")`).to.equal(tagValue);
+            if (isYamlFile(s3File.filename) || s3File.filename.endsWith(".info")) {
+              expect(s3File.tags?.get(tagKey), `${s3File.filename}.tags?.get("${tagKey}")`).to.equal(tagValue);
+            } else {
+              expect(s3File.tags?.get(tagKeyExtra), `${s3File.filename}.tags?.get("${tagKeyExtra}")`).to.equal(tagValueExtra);
+            }
           }
           done();
         }).catch((error) => {
@@ -609,10 +619,15 @@ describe("TestManager Integration", () => {
           expect(s3Files.length, "s3Files.length").to.equal(3);
           // Check that the recurring=true tag is added
           const [tagKey, tagValue]: [string, string] = s3.defaultTestFileTags().entries().next().value;
+          const [tagKeyExtra, tagValueExtra]: [string, string] = s3.defaultTestExtraFileTags().entries().next().value;
           expect(typeof tagKey, "typeof tagKey").to.equal("string");
           for (const s3File of s3Files) {
             expect(s3File.tags, "s3File.tags").to.not.equal(undefined);
-            expect(s3File.tags?.get(tagKey), `${s3File.filename}.tags?.get("${tagKey}")`).to.equal(tagValue);
+            if (isYamlFile(s3File.filename) || s3File.filename.endsWith(".info")) {
+              expect(s3File.tags?.get(tagKey), `${s3File.filename}.tags?.get("${tagKey}")`).to.equal(tagValue);
+            } else {
+              expect(s3File.tags?.get(tagKeyExtra), `${s3File.filename}.tags?.get("${tagKeyExtra}")`).to.equal(tagValueExtra);
+            }
           }
           done();
         }).catch((error) => {
@@ -707,10 +722,15 @@ describe("TestManager Integration", () => {
           expect(s3Files.length, "s3Files.length").to.equal(5);
           // Check that the recurring=true tag is added
           const [tagKey, tagValue]: [string, string] = s3.defaultTestFileTags().entries().next().value;
+          const [tagKeyExtra, tagValueExtra]: [string, string] = s3.defaultTestExtraFileTags().entries().next().value;
           expect(typeof tagKey, "typeof tagKey").to.equal("string");
           for (const s3File of s3Files) {
             expect(s3File.tags, "s3File.tags").to.not.equal(undefined);
-            expect(s3File.tags?.get(tagKey), `${s3File.filename}.tags?.get("${tagKey}")`).to.equal(tagValue);
+            if (isYamlFile(s3File.filename) || s3File.filename.endsWith(".info")) {
+              expect(s3File.tags?.get(tagKey), `${s3File.filename}.tags?.get("${tagKey}")`).to.equal(tagValue);
+            } else {
+              expect(s3File.tags?.get(tagKeyExtra), `${s3File.filename}.tags?.get("${tagKeyExtra}")`).to.equal(tagValueExtra);
+            }
           }
           done();
         }).catch((error) => {
@@ -1713,12 +1733,17 @@ describe("TestManager Integration", () => {
             expect(s3Files.length, "s3Files.length").to.equal(3);
             // Check that the test=true tag is added and recurring=true is removed
             const [testTagKey, testTagValue]: [string, string] = s3.defaultTestFileTags().entries().next().value;
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const [tagKeyExtra, tagValueExtra]: [string, string] = s3.defaultTestExtraFileTags().entries().next().value;
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const [recurringTagKey, recurringTagValue]: [string, string] = defaultRecurringFileTags().entries().next().value;
             expect(typeof testTagKey, "typeof tagKey").to.equal("string");
             for (const s3File of s3Files) {
               expect(s3File.tags, "s3File.tags").to.not.equal(undefined);
-              expect(s3File.tags?.get(testTagKey), `${s3File.filename}.tags?.get("${testTagKey}")`).to.equal(testTagValue);
+              if (isYamlFile(s3File.filename) || s3File.filename.endsWith(".info")) {
+                expect(s3File.tags?.get(testTagKey), `${s3File.filename}.tags?.get("${testTagKey}")`).to.equal(testTagValue);
+              } else {
+                expect(s3File.tags?.get(tagKeyExtra), `${s3File.filename}.tags?.get("${tagKeyExtra}")`).to.equal(tagValueExtra);
+              }
               expect(s3File.tags?.get(recurringTagKey), `${s3File.filename}.tags?.get("${recurringTagKey}")`).to.equal(undefined);
             }
             done();

--- a/controller/pages/api/util/testmanager.ts
+++ b/controller/pages/api/util/testmanager.ts
@@ -1333,23 +1333,28 @@ export abstract class TestManager {
         // Upload files
         const uploadPromises: Promise<PpaasS3File | void>[] = [uploadFile(yamlFile, s3Folder, fileTags)];
         // additionalFiles - Do this last so we can upload them at the same time
-        uploadPromises.push(...(additionalFiles.map((file: File) => uploadFile(file, s3Folder, fileTags))));
+        uploadPromises.push(...(additionalFiles.map((file: File) => uploadFile(file, s3Folder, fileTags || s3.defaultTestExtraFileTags()))));
         if (!editSchedule) {
           // copyFiles, just copy them from the old s3 location to the new one
           uploadPromises.push(...(copyFiles.map((file: PpaasS3File) => {
-            file.tags = fileTags;
+            file.tags = fileTags || s3.defaultTestExtraFileTags();
             return file.copy({ destinationS3Folder: s3Folder });
           })));
         } else {
-          // If we're changing from non-recurring to recurring or vice-versa we need to edit the existing file tags.
-          const updateTags: Map<string, string> = fileTags || s3.defaultTestFileTags(); // If fileTags is truthy it's recurring
+          const s3StatusFilename: string = createS3StatusFilename(ppaasTestId);
           uploadPromises.push(...(copyFiles.map((file: PpaasS3File) => {
-            file.tags = updateTags;
+            // If we're changing from non-recurring to recurring or vice-versa we need to edit the existing file tags.
+            // yaml and status files need defaultTestFileTags, all others should be defaultTestExtraFileTags
+            file.tags = fileTags
+              ? fileTags
+              : isYamlFile(file.filename) || file.filename === s3StatusFilename // yaml and status files are test files
+                ? s3.defaultTestFileTags()
+                : s3.defaultTestExtraFileTags();
             return file.updateTags();
           })));
         }
         // Store encrypted environment variables in s3
-        uploadPromises.push(new PpaasEncryptEnvironmentFile({ s3Folder, environmentVariablesFile, tags: fileTags }).upload());
+        uploadPromises.push(new PpaasEncryptEnvironmentFile({ s3Folder, environmentVariablesFile, tags: fileTags || s3.defaultTestExtraFileTags() }).upload());
         // Wait for all uploads to complete
         await Promise.all(uploadPromises);
 

--- a/controller/pages/api/util/testscheduler.ts
+++ b/controller/pages/api/util/testscheduler.ts
@@ -36,6 +36,7 @@ import {
 import { TestManager, defaultRecurringFileTags } from "./testmanager";
 import { formatError, getHourMinuteFromTimestamp } from "./clientutil";
 import type { EventInput } from "@fullcalendar/core";
+import { IS_RUNNING_IN_AWS } from "./authclient";
 import { PpaasEncryptS3File } from "./ppaasencrypts3file";
 
 const { sleep } = util;
@@ -397,7 +398,7 @@ export class TestScheduler implements TestSchedulerItem {
       // Start background task to delete old files
       (async () => {
         // Don't start right away, delay to sometime within today
-        let nextLoop: number = Date.now() + Math.floor(Math.random() * ONE_DAY);
+        let nextLoop: number = Date.now() + (IS_RUNNING_IN_AWS ? Math.floor(Math.random() * ONE_DAY) : 0);
         if (nextLoop > Date.now()) {
           const delay = nextLoop - Date.now();
           log("Delete Historical Loop: nextLoop: " + new Date(nextLoop), LogLevel.DEBUG, { delay, nextLoop });

--- a/controller/policy/bucket-expiration-policy.xml
+++ b/controller/policy/bucket-expiration-policy.xml
@@ -19,6 +19,19 @@
     </Filter>
     <Status>Enabled</Status>
     <Expiration>
+      <Days>730</Days>
+    </Expiration>
+  </Rule>
+  <Rule>
+    <ID>Expire Extra File Uploads</ID>
+    <Filter>
+      <Tag>
+        <Key>test</Key>
+        <Value>false</Value>
+      </Tag>
+    </Filter>
+    <Status>Enabled</Status>
+    <Expiration>
       <Days>180</Days>
     </Expiration>
   </Rule>


### PR DESCRIPTION
- [Added new tags for extra files from tests](https://github.com/FamilySearch/pewpew/pull/188/commits/7f05322d8a2e8d3d8bd2ee82e0316680dca275c8)
  - Test files will be the yaml file, status file, and results files (these will be kept longer)
  - Test Extra files will be log files, environment variables, and all other files needed by the yaml or logged by the yaml
- [Added code to tag extra files correctly](https://github.com/FamilySearch/pewpew/pull/188/commits/f7e17ecca6cd31017a0ef88fd85b8fcb76425fa8)
  - Stdout, stderr, and all other files generated by the yaml will be tagged as Test Extra files and be tagged for deletion accordingly
- [Added code to tag extra files correctly](https://github.com/FamilySearch/pewpew/pull/188/commits/46a823b2670fececc22fe55502f6e91da125e99d)
  - Additional files uploaded to the test, or additional files being copied from the old s3 location will be tagged as Test Extra files
  - Environment variable files will be tagged as Test Extra files
  - When changing from recurring to non-recurring, only yaml and test status files will be tagged as Test files, all others will be tagged as Extra files
- [Updated the bucket expiration so that test files are 2 years and all extra files are 6 months](https://github.com/FamilySearch/pewpew/pull/188/commits/66182de99fc2927e1e47d7704f41fb3254253a78)
- [Updated the integration tests to check the new test extra tags](https://github.com/FamilySearch/pewpew/pull/188/commits/5f977dccc47a9dae6c72cc43f88bcb7e0623f9ad)
- [Added code to validate that the logger files are tagged as extra](https://github.com/FamilySearch/pewpew/pull/188/commits/bc4e21183d157c1ce5e51c0e207438b61fe8e606)
- [Added code to clear tests off of the calendar after 1 year (or configured)](https://github.com/FamilySearch/pewpew/pull/188/commits/ede686c1cb1221cf0072fabc33cb42b0409ad304)
  - if RUN_HISTORICAL_DELETE is true, then it will remove things off the calendar after DELETE_OLD_FILES_DAYS (365 default) days.

Common:
![image](https://github.com/FamilySearch/pewpew/assets/16921270/261c2047-e503-4e0c-8fb6-8efe8ffd806f)

Controller:
![image](https://github.com/FamilySearch/pewpew/assets/16921270/ee6caa03-35be-4989-af9c-e25d096ac9e2)

Overall:
![image](https://github.com/FamilySearch/pewpew/assets/16921270/671227ca-e1c6-4a3e-930b-3d709c0e218e)

