### PR TITLE
Fixed issue with shared s3 buckets (#221)

### DIFF
--- a/common/src/util/s3.ts
+++ b/common/src/util/s3.ts
@@ -41,6 +41,7 @@ export type { S3File };
 const gunzip = promisify(zlibGunzip);
 const writeFile = promisify(fsWriteFile);
 
+export const SHARED_ENVIRONMENT_PREFIX: string = process.env.SHARED_ENVIRONMENT_PREFIX || "s3-environment/";
 export let BUCKET_NAME: string;
 export let BUCKET_URL: string;
 export let KEYSPACE_PREFIX: string;


### PR DESCRIPTION
Merging https://github.com/FamilySearch/pewpew/pull/221 into the Scripting branch.

- PPaasTestStatus.getAllStatus on the root s3 folder were finding tests from the shared subfolders on shared s3 buckets. It was then erroring when trying to load the status for those files
- Added export constant for the shared folder which can be overridden by SHARED_ENVIRONMENT_PREFIX env
- Added code to the getAllStatus function to ignore s3 keys that start with SHARED_ENVIRONMENT_PREFIX when our KEYSPACE_PREFIX is an empty string