### PR TITLE
Fixed a typo in the provider docs

### DIFF
--- a/guide/build-guide.sh
+++ b/guide/build-guide.sh
@@ -33,7 +33,7 @@ wasm-pack build --release -t bundler -d $WASM_OUTPUT_REACT_DIR --scope fs
 
 # build the results viewer (which includes putting the output into the book's src)
 cd $RESULTS_VIEWER_REACT_DIR
-npm install
+npm ci
 npm run build
 
 # build the book

--- a/guide/serve-guide.sh
+++ b/guide/serve-guide.sh
@@ -33,7 +33,7 @@ wasm-pack build --release -t bundler -d $WASM_OUTPUT_REACT_DIR --scope fs
 
 # build the results viewer (which includes putting the output into the book's src)
 cd $RESULTS_VIEWER_REACT_DIR
-npm install
+npm ci
 npm run build
 
 # build the book

--- a/guide/src/config/providers-section.md
+++ b/guide/src/config/providers-section.md
@@ -15,7 +15,7 @@ Example:
 ```yaml
 providers:
   - session:
-    - endpoint:
+    - response:
         auto_return: force
   - username:
     - file:
@@ -166,12 +166,31 @@ The `file` *provider_type* reads data from a file. Every line in the file is rea
 
   When enabled there is no sense of "fairness" in the randomization. Any record in the file could be used more than once before other records are used.
 
+**Example**, the following:
+```yaml
+providers:
+  - username:
+    - file:
+      path: "usernames.csv"
+      repeat: true
+      random: true
+```
+
 ## response
 Unlike other *provider_type*s `response` does not automatically receive data from a source. Instead a `response` provider is available to be a "sink" for data originating from an HTTP response. The `response` provider has the following parameters.
 
 - **`auto_return`** <sub><sup>*Optional*</sup></sub> - This parameter specifies that when this provider is used and an individual endpoint call concludes, the value it got from this provider should be sent back to the provider. Valid options for this parameter are `block`, `force`, and `if_not_full`. See the `send` parameter under the [endpoints.provides subsection](./endpoints-section.md#provides-subsection) for details on the effect of these options.
 - **`buffer`** <sub><sup>*Optional*</sup></sub> - Specifies the soft limit for a provider's buffer. This can be indicated with an integer greater than zero or the value `auto`. The value `auto` indicates that if the provider's buffer becomes empty it will automatically increase the buffer size to help prevent the provider from becoming empty again in the future. Defaults to `auto`.
 - **`unique`** - <sub><sup>*Optional*</sup></sub> A boolean value which when `true` makes the provider a "unique" provider--meaning each item within the provider will be a unique JSON value without duplicates. Defaults to `false`.
+
+**Example**, the following:
+```yaml
+providers:
+  - session:
+    - response:
+        buffer: 1000
+        auto_return: if_not_full
+```
 
 ## list
 The `list` *provider_type* creates a means of specifying an array of static values to be used as a provider.


### PR DESCRIPTION
- The example had endpoint rather than response
- Added some additional examples