### PR TITLE
Fix multiple test results bug

### DIFF
--- a/controller/.storybook/main.ts
+++ b/controller/.storybook/main.ts
@@ -20,22 +20,22 @@ const config: StorybookConfig = {
       propFilter: prop => prop.parent ? !/node_modules/.test(prop.parent.fileName) : true
     }
   },
-  webpackFinal: (config: Configuration) => {
-    if (!config.resolve) { config.resolve = {}; }
-    config.resolve.fallback = {
-      ...(config.resolve.fallback || {}),
+  webpackFinal: (webpackConfig: Configuration) => {
+    if (!webpackConfig.resolve) { webpackConfig.resolve = {}; }
+    webpackConfig.resolve.fallback = {
+      ...(webpackConfig.resolve.fallback || {}),
       "fs": false,
       "util": false,
       "path": false,
       "assert": false,
-      "crypto": false,
+      "crypto": false
     };
-    if (!config.experiments) { config.experiments = {}; }
-    config.experiments.asyncWebAssembly = true;
-    if (!config.output) { config.output = {}; }
+    if (!webpackConfig.experiments) { webpackConfig.experiments = {}; }
+    webpackConfig.experiments.asyncWebAssembly = true;
+    if (!webpackConfig.output) { webpackConfig.output = {}; }
     // config.output.publicPath = "/";
-    config.output.webassemblyModuleFilename = 'static/wasm/[modulehash].wasm';
-    return config;
+    webpackConfig.output.webassemblyModuleFilename = "static/wasm/[modulehash].wasm";
+    return webpackConfig;
   },
   framework: {
     name: "@storybook/nextjs",

--- a/controller/.storybook/preview.js
+++ b/controller/.storybook/preview.js
@@ -5,8 +5,8 @@ import { RouterContext } from "next/dist/shared/lib/router-context.shared-runtim
 /** @type { import('@storybook/react').Preview } */
 const preview = {
   nextRouter: {
-    Provider: RouterContext.Provider,
-  },
+    Provider: RouterContext.Provider
+  }
   // Can't get this to work
   // https://storybook.js.org/blog/integrate-nextjs-and-storybook-automatically/
   // nextjs: {

--- a/controller/.storybook/tsconfig.json
+++ b/controller/.storybook/tsconfig.json
@@ -17,6 +17,8 @@
     "jsx": "react"
   },
   "include": [
+    "./*.ts",
+    "./*.js",
     "../types/**/*.ts",
     "../components/**/*.ts",
     "../components/**/*.tsx"

--- a/controller/.storybook/tsconfig.json
+++ b/controller/.storybook/tsconfig.json
@@ -18,6 +18,7 @@
   },
   "include": [
     "./*.ts",
+    "./*.js",
     "../types/**/*.ts",
     "../components/**/*.ts",
     "../components/**/*.tsx"

--- a/controller/.storybook/tsconfig.json
+++ b/controller/.storybook/tsconfig.json
@@ -18,7 +18,6 @@
   },
   "include": [
     "./*.ts",
-    "./*.js",
     "../types/**/*.ts",
     "../components/**/*.ts",
     "../components/**/*.tsx"

--- a/controller/test/singleTestResult.js
+++ b/controller/test/singleTestResult.js
@@ -199,4 +199,4 @@ export const testJsonResponse = [
       }
     ]
   ]
-]
+];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,6 +25,7 @@ export default [{
     "common/lib",
     "controller/lib",
     "controller/storybook-static",
+    "controller/test/**.js",
     "controller/next-env.d.ts",
     "eslint.config.mjs"
   ],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,8 +25,6 @@ export default [{
     "common/lib",
     "controller/lib",
     "controller/storybook-static",
-    "controller/.storybook",
-    "controller/**/**.js",
     "controller/next-env.d.ts",
     "eslint.config.mjs"
   ],
@@ -50,7 +48,8 @@ export default [{
         "./common/tsconfig.json",
         "./agent/tsconfig.json",
         "./controller/tsconfig.json",
-        "./controller/tsconfig.test.json"
+        "./controller/tsconfig.test.json",
+        "./controller/.storybook/tsconfig.json",
       ],
     },
   },


### PR DESCRIPTION
- [Fixed the bug with multiple results files and switching between](https://github.com/FamilySearch/pewpew/commit/b6b6978bcce23a9e0a06c99cda4854498dc01fed)
  - The null pointer throws on redraw. All the calculations and freeing of memory must be done within a setState block while the data is static
- [Updated eslint to include storybook](https://github.com/FamilySearch/pewpew/commit/a8574f3ec2992f56d20492ff2a89e84be9e1767b)