### PR TITLE
PewRL fixes and updates

### DIFF
--- a/guide/results-viewer-react/src/components/Modal/index.tsx
+++ b/guide/results-viewer-react/src/components/Modal/index.tsx
@@ -93,6 +93,7 @@ interface ModalProps {
   children?: React.ReactNode;
   isReady?: boolean;
   scrollable?: boolean;
+  initialDisplay?: boolean;
 }
 
 export interface ModalObject {
@@ -136,9 +137,10 @@ export const Modal = forwardRef(({
   submitText = "submit",
   children,
   isReady,
-  scrollable
+  scrollable,
+  initialDisplay = false
 }: ModalProps, ref: Ref<ModalObject>) => {
-  const [display, setDisplay] = useState(false);
+  const [display, setDisplay] = useState(initialDisplay);
   let windowOffset: number = 0;
 
   useImperativeHandle(ref, () => {

--- a/guide/results-viewer-react/src/components/YamlUrls/QueryParamsView.tsx
+++ b/guide/results-viewer-react/src/components/YamlUrls/QueryParamsView.tsx
@@ -1,0 +1,68 @@
+import { PewPewHeader, PewPewQueryParam } from "../../util/yamlwriter";
+import { PewPewQueryParamStringType } from ".";
+import React from "react";
+
+export interface QueryParamsViewProps {
+    id: string;
+    queryParamList: PewPewQueryParam[];
+    removeParam: (param: PewPewQueryParam) => void;
+    changeParam: (paramIndex: number, type: PewPewQueryParamStringType, value: string) => void;
+    addParam: () => void;
+}
+
+function QueryParamsView ({ id, queryParamList, removeParam, changeParam, addParam }: QueryParamsViewProps): JSX.Element {
+    const styles: Record<string, React.CSSProperties> = {
+        headersDisplay: {
+        marginTop: "10px",
+        maxHeight: "300px",
+        overflow: "auto"
+        },
+        gridContainer: {
+        display: "grid",
+        gap: "10px"
+        },
+        gridHeader: {
+        display: "grid",
+        gridTemplateColumns: "auto 1fr 2fr",
+        gap: "10px",
+        fontWeight: "bold",
+        height: "20px"
+        },
+        gridRows: {
+        display: "grid",
+        gridTemplateColumns: "auto 1fr 2fr",
+        gap: "10px",
+        alignItems: "stretch"
+        },
+        input: {
+        boxSizing: "border-box"
+        },
+        button: {
+        boxSizing: "border-box",
+        whiteSpace: "nowrap"
+        }
+    };
+    return (
+        <React.Fragment>
+            <div style={styles.headersDisplay}>
+            <div style={styles.gridContainer}>
+                <div style={styles.gridHeader}>
+                <span><button name={id} onClick={() => addParam()}>+</button></span>
+                <span>Name</span>
+                <span>Value</span>
+                </div>
+                {queryParamList.length === 0 && <span>No Query Params yet, click "+" to create one</span>}
+                {queryParamList.map((param: PewPewHeader, index: number) => (
+                <div key={index} style={styles.gridRows}>
+                    <button style={styles.button} onClick={() => removeParam(param)}>X</button>
+                    <input style={styles.input} id={`urlHeaderKey@${index}`} name={id} value={param.name} onChange={(event) => changeParam(index, "name", event.target.value)} />
+                    <input style={styles.input} id={`urlHeaderValue@${index}`} name={id} value={param.value} onChange={(event) => changeParam(index, "value", event.target.value)} />
+                </div>
+                ))}
+            </div>
+            </div>
+        </React.Fragment>
+    );
+}
+
+export default QueryParamsView;

--- a/guide/results-viewer-react/src/components/YamlUrls/RequestBodyView.tsx
+++ b/guide/results-viewer-react/src/components/YamlUrls/RequestBodyView.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+export interface RequestBodyViewProps {
+    requestBody: object | undefined;
+    updateRequestBody: (newRequestBody: object) => void;
+}
+
+function RequestBodyView ({ requestBody, updateRequestBody }: RequestBodyViewProps): JSX.Element {
+    const [requestBodyInEdit, setRequestBodyInEdit] = React.useState<string>(JSON.stringify(requestBody, null, 2).replace(/\\n/g, "\n").replace(/^"|"$/g, ""));
+
+    const requestBodyDisplayStyle: React.CSSProperties = {
+        fontFamily: "monospace",
+        width: "100%",
+        height: "270px",
+        overflow: "auto",
+        border: "1px solid #ccc",
+        padding: "10px",
+        backgroundColor: "#2e3438",
+        resize: "none",
+        tabSize: 2,
+        boxSizing: "border-box"
+    };
+
+    const handleEditorInput = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+        const newRequestBody = event.target.value;
+        setRequestBodyInEdit(newRequestBody);
+        try {
+            updateRequestBody(JSON.parse(newRequestBody));
+        } catch (error) {
+            console.error(error);
+        }
+    };
+
+    return (
+        <React.Fragment>
+            <textarea
+                value={requestBodyInEdit}
+                onChange={handleEditorInput}
+                style={requestBodyDisplayStyle}
+            />
+        </React.Fragment>
+    );
+}
+
+export default RequestBodyView;

--- a/guide/results-viewer-react/src/components/YamlUrls/RequestBodyView.tsx
+++ b/guide/results-viewer-react/src/components/YamlUrls/RequestBodyView.tsx
@@ -1,3 +1,4 @@
+import { LogLevel, log } from "../../util/log";
 import React from "react";
 
 export interface RequestBodyViewProps {
@@ -27,7 +28,7 @@ function RequestBodyView ({ requestBody, updateRequestBody }: RequestBodyViewPro
         try {
             updateRequestBody(JSON.parse(newRequestBody));
         } catch (error) {
-            console.error(error);
+            log("Invalid JSON", LogLevel.WARN, error);
         }
     };
 

--- a/guide/results-viewer-react/src/components/YamlUrls/RequestDetailsTabs.tsx
+++ b/guide/results-viewer-react/src/components/YamlUrls/RequestDetailsTabs.tsx
@@ -1,15 +1,33 @@
 import HeadersView, { HeadersViewProps } from "./HeadersView";
+import QueryParamsView, { QueryParamsViewProps } from "./QueryParamsView";
+import RequestBodyView, { RequestBodyViewProps } from "./RequestBodyView";
 import ResponseView, { ResponseViewProps } from "./ResponseView";
 import React from "react";
 import { TabType } from ".";
 
-interface RequestDetailsTabsProps extends HeadersViewProps, ResponseViewProps {
+interface RequestDetailsTabsProps extends HeadersViewProps, ResponseViewProps, QueryParamsViewProps, RequestBodyViewProps {
     activeTab: TabType;
     handleChangeTab: (tab: TabType) => void;
   }
 
-  function RequestDetailsTabs ({ id, headersList, removeHeader, changeHeader, addHeader, response, error, activeTab, handleChangeTab }: RequestDetailsTabsProps): JSX.Element {
-    const tabs: TabType[] = ["Headers", "Response"];
+  function RequestDetailsTabs ({
+    id,
+    headersList,
+    removeHeader,
+    changeHeader,
+    addHeader,
+    queryParamList,
+    removeParam,
+    changeParam,
+    addParam,
+    response,
+    error,
+    activeTab,
+    handleChangeTab,
+    requestBody,
+    updateRequestBody
+  }: RequestDetailsTabsProps): JSX.Element {
+    const tabs: TabType[] = ["Headers", "Query Params", "Request Body", "Response"];
 
     return (
       <div>
@@ -33,6 +51,8 @@ interface RequestDetailsTabsProps extends HeadersViewProps, ResponseViewProps {
         <div role="tabpanel" id={`tabpanel-${activeTab}`} aria-labelledby={`tab-${activeTab}`}>
           {activeTab === "Headers" && <HeadersView id={id} headersList={headersList} removeHeader={removeHeader} changeHeader={changeHeader} addHeader={addHeader} />}
           {activeTab === "Response" && <ResponseView response={response} error={error} />}
+          {activeTab === "Query Params" && <QueryParamsView id={id} queryParamList={queryParamList} removeParam={removeParam} changeParam={changeParam} addParam={addParam} />}
+          {activeTab === "Request Body" && <RequestBodyView requestBody={requestBody} updateRequestBody={updateRequestBody} />}
         </div>
       </div>
     );

--- a/guide/results-viewer-react/src/components/YamlUrls/index.tsx
+++ b/guide/results-viewer-react/src/components/YamlUrls/index.tsx
@@ -114,10 +114,6 @@ export function Urls ({ data: { headers, ...data }, ...props }: UrlProps) {
   const modalRef = useRef<ModalObject| null>(null);
   useEffectModal(modalRef);
 
-  useEffect(() => {
-    modalRef.current?.openModal();
-  }, []);
-
   // Changes the state of authenticated button when default is checked or unchecked
   useEffect(() => {
     // Add/delete from headersMap/headers
@@ -250,6 +246,7 @@ export function Urls ({ data: { headers, ...data }, ...props }: UrlProps) {
         onSubmit={updateEndpointHandler}
         isReady={enableSubmit}
         scrollable={false}
+        initialDisplay={true}
         >
         <Row style={{ alignItems: "start"}}>
             <Span style={{ margin: 0 }}>

--- a/guide/results-viewer-react/src/components/YamlUrls/index.tsx
+++ b/guide/results-viewer-react/src/components/YamlUrls/index.tsx
@@ -266,8 +266,22 @@ export function Urls ({ data: { headers, ...data }, ...props }: UrlProps) {
                 <Label style={{ fontSize: "14px" }} htmlFor="urlUrl"> Endpoint {checked}</Label>
                 <p style={{ fontSize: "10px", margin: 0 }}> (must be in the form "https://www.[url]" or "http://www.[url]")</p>
               </Row>
-              <Row>
+              <Row style={{ position: "relative"}}>
                 <input style={{ ...urlStyle, width: "100%" }} onChange={(event) => setUrl(event.target.value)} title={urlTitle} name={data.id} value={url} id="urlUrl" type="text" />
+                {url && (
+                  <button
+                    onClick={() => setUrl("")}
+                    style={{
+                      position: "absolute",
+                      right: "45px",
+                      border: "none",
+                      background: "transparent",
+                      cursor: "pointer"
+                    }}
+                  >
+                    ×
+                  </button>
+                )}
                 <button style={{ cursor: "pointer" }} onClick={makeRequest} disabled={invalidUrl} title={invalidUrl ? "Endpoint URL is not valid" : "Attempt to call this Endpoint"} type="submit">Test</button>
               </Row>
             </ModalInput>

--- a/guide/results-viewer-react/src/util/yamlwriter.ts
+++ b/guide/results-viewer-react/src/util/yamlwriter.ts
@@ -13,7 +13,7 @@ export interface Har {
     pages: Page[],
   }
 }
-/** This is the type for all headers added to any anypoints */
+/** This is the type for all headers added to any endpoints */
 export interface HarHeader {
   name: string;
   value: string;
@@ -21,6 +21,14 @@ export interface HarHeader {
 export interface PewPewHeader extends HarHeader {
   id: string;
 }
+
+/** This is the type for all query params added to any endpoints */
+export interface PewPewQueryParam {
+  id: string;
+  name: string;
+  value: string;
+}
+
 /** This is what an endpoint looks like from an incoming Har file */
 export interface HarEndpoint {
   id: string;
@@ -35,6 +43,7 @@ export interface PewPewAPI {
   id: string;
   url: string;
   headers: PewPewHeader[];
+  requestBody?: object;
   method: string;
   hitRate: string;
   authorization: null;


### PR DESCRIPTION
The following bug fixes and features are implemented:
- Set Edit Endpoint modal to open w/o using a useEffect
- Reset that modal when the “Close” button is clicked
- Receive and use query parameters
- Request body can be created and used in requests
- Create a button to clear the URL field
- The option for devkey is removed