### PR TITLE
Fix large logfiles api

### DIFF
--- a/controller/pages/api/json/[yamlFile]/[dateString]/[resultsFile].ts
+++ b/controller/pages/api/json/[yamlFile]/[dateString]/[resultsFile].ts
@@ -9,19 +9,20 @@ import { getS3Response } from "../../../util/s3";
 // We have to set this before we make any log calls
 logger.config.LogFileName = "ppaas-controller";
 
-async function getOrRedirect (
+async function getOrRedirect ({ request, response, resultsFile: filename, s3Folder, redirectToS3 }: {
   request: NextApiRequest,
   response: NextApiResponse<GetObjectCommandOutput["Body"] | Buffer | TestManagerError>,
-  filename: string,
-  s3Folder: string
-): Promise<void> {
+  resultsFile: string,
+  s3Folder: string,
+  redirectToS3?: boolean
+}): Promise<void> {
   try {
     if (!filename || !s3Folder) {
       response.status(400).json({ message: `method ${request.method} must have a file path` });
       return;
     }
 
-    const found = await getS3Response({ request, response, filename, s3Folder});
+    const found = await getS3Response({ request, response, filename, s3Folder, redirectToS3 });
     if (found) { return; }
 
     // 404 - Not Found
@@ -32,30 +33,33 @@ async function getOrRedirect (
   }
 }
 
-export default async (req: NextApiRequest, res: NextApiResponse<GetObjectCommandOutput["Body"] | Buffer | TestManagerError>) => {
+export default async (request: NextApiRequest, response: NextApiResponse<GetObjectCommandOutput["Body"] | Buffer | TestManagerError>) => {
 
-  if (req.method === "GET") {
+  if (request.method === "GET") {
     // Allow Read-Only to view
-    const authPermissions: AuthPermissions | undefined = await authApi(req, res, AuthPermission.ReadOnly);
+    const authPermissions: AuthPermissions | undefined = await authApi(request, response, AuthPermission.ReadOnly);
     if (!authPermissions) {
       // If it's undefined we failed auth and already have set a response
       return;
     }
     try {
       const {
-        query: { yamlFile, dateString, resultsFile }
-      } = req;
-      log(`resultsFile: ${resultsFile}`, LogLevel.DEBUG, { query: req.query });
+        query: { yamlFile, dateString, resultsFile, redirect }
+      } = request;
+      log(`resultsFile: ${resultsFile}`, LogLevel.DEBUG, { query: request.query });
       if (resultsFile && !Array.isArray(resultsFile) && resultsFile.startsWith("stats-") && resultsFile.endsWith(".json")) {
-        await getOrRedirect(req, res, resultsFile, `${yamlFile}/${dateString}`);
+        // If it's a string treat it as truthy. I.e. ?redirect will redirect. Only ?redirect=false
+        // Any non string fall back to the default
+        const redirectToS3: boolean | undefined = typeof redirect === "string" ? redirect.toLowerCase() !== "false" : undefined;
+        await getOrRedirect({ request, response, resultsFile, s3Folder: `${yamlFile}/${dateString}`, redirectToS3 });
       } else {
-        res.status(400).json({ message: `method ${req.method} must have a json file` });
+        response.status(400).json({ message: `method ${request.method} must have a json file` });
       }
     } catch (error) {
-      log(`${req.method} ${req.url} failed: ${error}`, LogLevel.ERROR, error);
-      res.status(500).json(createErrorResponse(req, error));
+      log(`${request.method} ${request.url} failed: ${error}`, LogLevel.ERROR, error);
+      response.status(500).json(createErrorResponse(request, error));
     }
   } else {
-    res.status(400).json({ message: `method ${req.method} is not supported for this endpoint` });
+    response.status(400).json({ message: `method ${request.method} is not supported for this endpoint` });
   }
 };

--- a/controller/pages/index.tsx
+++ b/controller/pages/index.tsx
@@ -135,7 +135,8 @@ const TestStatusPage = ({
   // Lazy load the console errors on the client-side
   useEffect(() => {
     log("console errors useEffect", LogLevel.DEBUG, testData?.s3Folder);
-    if (testData) {
+    // If it's not running yet there's no file
+    if (testData?.status && (testData.status === TestStatus.Running || testData.status === TestStatus.Finished || testData.status === TestStatus.Failed)) {
       const url = formatPageHref(API_ERROR_FORMAT(testData.s3Folder));
       log("console errors url", LogLevel.DEBUG, url);
       // If we're client-side the cookie gets passed automatically


### PR DESCRIPTION
- [Added fix for tests not running yet, don't load std error](https://github.com/FamilySearch/pewpew/commit/48c003c267e64310b6a8db13cec42fd3ff03054e)
- [Added code to s3 APIs to return 413 on large returnstroller.json](https://github.com/FamilySearch/pewpew/commit/b0b744a24dd0ee1dd8714a9012fc5f4dae80026a)
  - By default Next.js just returns an empty string/body and 200 response (after a timeout) on large API responses. Default is 4MB.
- [Updated API's to allow a redirect parameter](https://github.com/FamilySearch/pewpew/commit/4c7353f351fa8c38e0730691e1285277d9adf3fd)
  - The resultsFile and errorFile APIs will allow a ?redirect paramter to force redirect to S3 with a presigned url
  - On the test status page if the console std error file returns a 413 it will add the ?redirect query param to the link

![image](https://github.com/user-attachments/assets/cb50e0b6-d483-4c84-a9bc-c12862e3a935)
![image](https://github.com/user-attachments/assets/c3126649-9d9b-495e-9ba6-1fe7978a5d64)
