### PR TITLE
Agent buildtest sqs scripting

### DIFF
--- a/agent/acceptance/tests.spec.ts
+++ b/agent/acceptance/tests.spec.ts
@@ -4,7 +4,10 @@ import {
   util
 } from "@fs/ppaas-common";
 import axios, { AxiosError, AxiosResponse as Response } from "axios";
+import { buildTest } from "../src/tests";
 import { expect } from "chai";
+
+const ACCEPTANCE_SEND_TO_QUEUE: boolean = process.env.ACCEPTANCE_SEND_TO_QUEUE !== undefined;
 
 const integrationUrl = "http://" + (process.env.BUILD_APP_URL || `localhost:${process.env.PORT || "8080"}`);
 log("integrationUrl = " + integrationUrl);
@@ -61,7 +64,12 @@ describe("Tests Integration", () => {
 
   describe("/tests/build", () => {
     it("GET tests/build should respond 200 OK", (done: Mocha.Done) => {
-      waitForSuccess().then(() => done()).catch((error) => done(error));
+      if (ACCEPTANCE_SEND_TO_QUEUE) {
+        // Put the message on the SQS queue and wait for S3/communications queue
+        buildTest({ sendToQueue: true, unitTest: true }).then(() => done()).catch((error) => done(error));
+      } else {
+        waitForSuccess().then(() => done()).catch((error) => done(error));
+      }
     });
   });
 });

--- a/agent/src/tests.ts
+++ b/agent/src/tests.ts
@@ -2,11 +2,15 @@ import {
   LogLevel,
   PEWPEW_BINARY_FOLDER,
   PEWPEW_VERSION_LATEST,
+  PpaasS3File,
   PpaasTestId,
   PpaasTestMessage,
+  PpaasTestStatus,
   TestMessage,
+  TestStatus,
   log,
   s3,
+  sqs,
   util
 } from "@fs/ppaas-common";
 import { NextFunction, Request, Response, Router } from "express";
@@ -14,6 +18,7 @@ import ExpiryMap from "expiry-map";
 import { PewPewTest } from "./pewpewtest";
 import { config as healthcheckConfig } from "./healthcheck";
 import { join as pathJoin } from "path";
+import { tmpdir } from "os";
 
 const UNIT_TEST_FOLDER = process.env.UNIT_TEST_FOLDER || "test";
 export const yamlFile = "basicwithenv.yaml";
@@ -51,10 +56,68 @@ endpoints:
 /** key is an id/timestamp, result is either boolean (finished/not finished) or error */
 const buildTestMap = new ExpiryMap<string, boolean | unknown>(600_000); // 10 minutes
 
+async function pollTestStatusForFinished (ppaasTestStatus: PpaasTestStatus): Promise<TestStatus> {
+  let previousDate: Date = await ppaasTestStatus.readStatus();
+  if (ppaasTestStatus.status === TestStatus.Finished || ppaasTestStatus.status === TestStatus.Failed) {
+    return ppaasTestStatus.status;
+  }
+  await util.poll(async () => {
+    const newDate: Date = await ppaasTestStatus.readStatus();
+    if (newDate.getTime() !== previousDate.getTime()) {
+      log("pollTestStatusForFinished status updated: " + ppaasTestStatus.status, LogLevel.WARN, { previousDate, newDate, ...ppaasTestStatus.getTestStatusMessage() });
+      previousDate = newDate;
+    }
+    return ppaasTestStatus.status === TestStatus.Finished || ppaasTestStatus.status === TestStatus.Failed;
+  }, 180000);
+  return ppaasTestStatus.status;
+}
+
+async function launchTestThroughQueue ({ ppaasTestId, ppaasTestMessage }: { ppaasTestId: PpaasTestId, ppaasTestMessage: PpaasTestMessage }) {
+  const { testId, s3Folder } = ppaasTestId;
+  const queueName = PpaasTestMessage.getAvailableQueueNames()[0];
+  // Create a dummy results file so we can get the remoteFileLocation
+  const resultsFile: PpaasS3File = new PpaasS3File({
+    filename: util.createStatsFileName(testId),
+    s3Folder,
+    localDirectory: tmpdir() || "/tmp"
+  });
+  const userId = "acceptance-test";
+  const startTime = Date.now();
+  const ppaasTestStatus = new PpaasTestStatus(
+    ppaasTestId,
+    {
+      startTime,
+      endTime: startTime + 60000,
+      resultsFilename: [resultsFile.filename],
+      status: TestStatus.Created,
+      queueName,
+      version: ppaasTestMessage.version,
+      userId
+    }
+  );
+  // We need to upload the default status before we send the message to the queue so the agent can read it.
+  const statusUrl = await ppaasTestStatus.writeStatus();
+  log(`PpaasTestStatus url: ${statusUrl}`, LogLevel.DEBUG, { statusUrl });
+
+  // Create our message in the scaling queue
+  await ppaasTestMessage.send(queueName);
+  // Put a message on the scale in queue so we don't scale back in
+  await sqs.sendTestScalingMessage(queueName);
+  // We succeeded! Yay!
+  log ("TestManager: New Load Test started", LogLevel.WARN, { testMessage: ppaasTestMessage.sanitizedCopy(), queueName, authPermissions: { userId } });
+  // TODO: Poll for results
+  const finalStatus = await pollTestStatusForFinished(ppaasTestStatus);
+  log("buildTest final status: " + finalStatus, LogLevel.WARN, { ...ppaasTestStatus.getTestStatusMessage() });
+  if (finalStatus !== TestStatus.Finished) {
+    throw new Error("buildTest final status: " + finalStatus);
+  }
+}
+
 export async function buildTest ({
   unitTest,
+  sendToQueue,
   ppaasTestId = PpaasTestId.makeTestId(yamlFile)
-}: { unitTest?: boolean, ppaasTestId?: PpaasTestId } = {}) {
+}: { unitTest?: boolean, sendToQueue?: boolean, ppaasTestId?: PpaasTestId } = {}) {
   // Make sure we can run a basic test
   try {
     const { testId, s3Folder } = ppaasTestId;
@@ -89,8 +152,13 @@ export async function buildTest ({
       userId: "buildTest"
     };
 
-    const pewPewTest: PewPewTest = new PewPewTest(new PpaasTestMessage(testMessage));
-    await pewPewTest.launch();
+    const ppaasTestMessage = new PpaasTestMessage(testMessage);
+    if (sendToQueue) {
+      await launchTestThroughQueue({ ppaasTestId, ppaasTestMessage });
+    } else {
+      const pewPewTest: PewPewTest = new PewPewTest(ppaasTestMessage);
+      await pewPewTest.launch();
+    }
     log(`${process.env.FS_SYSTEM_NAME} environment basic startup test succeeded!`, LogLevel.WARN, { duration: Date.now() - startTime });
   } catch (error) {
     healthcheckConfig.failHealthCheck = true;
@@ -126,13 +194,13 @@ export function init (): Router {
   router.get("/build", (req: Request, res: Response) => {
     // endpoint no jobId query param starts test returns a job id
     // endpoint with jobId returns the status of a job id
-    const { jobId } = req.query;
+    const { jobId, sendToQueue } = req.query;
     if (jobId === undefined) {
       try {
         const ppaasTestId = PpaasTestId.makeTestId(yamlFile);
         const newJobId = ppaasTestId.testId;
         buildTestMap.set(newJobId, false);
-        buildTest({ unitTest: true, ppaasTestId })
+        buildTest({ unitTest: true, ppaasTestId, sendToQueue: sendToQueue !== undefined })
         .then(() => buildTestMap.set(newJobId, true))
         .catch((error: unknown) => buildTestMap.set(newJobId, error));
         res.status(200).json({ jobId: newJobId });

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -1,8 +1,14 @@
 import * as ec2 from "./util/ec2";
 import * as logger from "./util/log";
+import * as ppaascommessage from "./ppaascommessage";
+import * as ppaass3message from "./ppaass3message";
+import * as ppaastestmessage from "./ppaastestmessage";
+import * as ppaasteststatus from "./ppaasteststatus";
 import * as s3 from "./util/s3";
+import * as s3file from "./s3file";
 import * as sqs from "./util/sqs";
 import * as util from "./util/util";
+import * as yamlparser from "./yamlparser";
 import {
   APPLICATION_NAME,
   PEWPEW_BINARY_EXECUTABLE,
@@ -34,9 +40,15 @@ export type {
 export {
   ec2,
   logger,
+  ppaascommessage,
+  ppaass3message,
+  ppaastestmessage,
+  ppaasteststatus,
   s3,
+  s3file,
   sqs,
   util,
+  yamlparser,
   log,
   LogLevel,
   APPLICATION_NAME,

--- a/common/src/ppaasteststatus.ts
+++ b/common/src/ppaasteststatus.ts
@@ -110,8 +110,12 @@ export class PpaasTestStatus implements TestStatusMessage {
     return this.ppaasTestId.s3Folder;
   }
 
-  // Get one initially
-  // Returns an object, false if not found, or true if unchanged
+  /**
+   * Internal function to get the latest TestStatusMessage
+   * @param ppaasTestId testId to retrieve
+   * @param lastModified if provided will only get changes
+   * @returns false if not found, true if unchanged, or the object
+   */
   protected static async getStatusInternal (ppaasTestId: PpaasTestId, lastModified?: Date): Promise<PpaasTestStatus | boolean> {
     const key = getKey(ppaasTestId);
     try {
@@ -232,6 +236,11 @@ export class PpaasTestStatus implements TestStatusMessage {
     return undefined;
   }
 
+  /**
+   * Reads the updated TestStatusMessage from S3 and returns the last modified date
+   * @param force Optional parameter to force redownloading
+   * @returns The date of the last modified of the file in S3
+   */
   public async readStatus (force?: boolean): Promise<Date> {
     const updatedStatus: PpaasTestStatus | boolean = await PpaasTestStatus.getStatusInternal(
       this.ppaasTestId,

--- a/controller/pages/api/util/testmanager.ts
+++ b/controller/pages/api/util/testmanager.ts
@@ -45,6 +45,8 @@ import {
   YamlParser,
   log,
   logger,
+  ppaass3message,
+  ppaasteststatus,
   s3,
   sqs,
   util
@@ -52,12 +54,8 @@ import {
 import type { Fields, File, Files } from "formidable";
 import PpaasEncryptEnvironmentFile, { ENCRYPTED_ENVIRONMENT_VARIABLES_FILENAME } from "./ppaasencryptenvfile";
 import { formatError, isYamlFile, latestPewPewVersion } from "./clientutil";
-import { createS3Filename as createS3MessageFilename } from "@fs/ppaas-common/dist/src/ppaass3message";
-import { createS3Filename as createS3StatusFilename } from "@fs/ppaas-common/dist/src/ppaasteststatus";
 import fs from "fs/promises";
 
-const sendTestScalingMessage = sqs.sendTestScalingMessage;
-const createStatsFileName = util.createStatsFileName;
 export const MAX_SAVED_TESTS_RECENT: number = parseInt(process.env.MAX_SAVED_TESTS_RECENT || "0", 10) || 10;
 export const MAX_SAVED_TESTS_CACHED: number = parseInt(process.env.MAX_SAVED_TESTS_CACHED || "0", 10) || 1000;
 const MIN_SEARCH_LENGTH: number = parseInt(process.env.MIN_SEARCH_LENGTH || "0", 10) || 0;
@@ -934,9 +932,9 @@ export abstract class TestManager {
           startTime: ppaasTestId.date.getTime()
         };
       // Check s3 for the files
-      const s3MessageFilename: string = createS3MessageFilename(ppaasTestId);
-      const s3StatusFilename: string = createS3StatusFilename(ppaasTestId);
-      const statsFileName: string = path.parse(createStatsFileName(testId)).name;
+      const s3MessageFilename: string = ppaass3message.createS3Filename(ppaasTestId);
+      const s3StatusFilename: string = ppaasteststatus.createS3Filename(ppaasTestId);
+      const statsFileName: string = path.parse(util.createStatsFileName(testId)).name;
       const pewpewOutFilename: string = logger.pewpewStdOutFilename(testId).split("-").slice(0,4).join("-");
       const s3Files: PpaasS3File[] = await PpaasS3File.getAllFilesInS3({ s3Folder, localDirectory });
       let yamlFile: string | undefined;
@@ -1325,7 +1323,7 @@ export abstract class TestManager {
             return file.copy({ destinationS3Folder: s3Folder });
           })));
         } else {
-          const s3StatusFilename: string = createS3StatusFilename(ppaasTestId);
+          const s3StatusFilename: string = ppaasteststatus.createS3Filename(ppaasTestId);
           uploadPromises.push(...(copyFiles.map((file: PpaasS3File) => {
             // If we're changing from non-recurring to recurring or vice-versa we need to edit the existing file tags.
             // yaml and status files need defaultTestFileTags, all others should be defaultTestExtraFileTags
@@ -1398,7 +1396,7 @@ export abstract class TestManager {
 
     // Create a dummy results file so we can get the remoteFileLocation
     const resultsFile: PpaasS3File = new PpaasS3File({
-      filename: createStatsFileName(testId),
+      filename: util.createStatsFileName(testId),
       s3Folder,
       localDirectory
     });
@@ -1436,7 +1434,7 @@ export abstract class TestManager {
     const ppaasTestMessage: PpaasTestMessage = new PpaasTestMessage(testMessage);
     await ppaasTestMessage.send(queueName);
     // Put a message on the scale in queue so we don't scale back in
-    await sendTestScalingMessage(queueName);
+    await sqs.sendTestScalingMessage(queueName);
     // We succeeded! Yay!
     log ("TestManager: New Load Test started", LogLevel.INFO, { testMessage: ppaasTestMessage.sanitizedCopy(), queueName, testData, authPermissions: getLogAuthPermissions(authPermissions) });
 


### PR DESCRIPTION
* Added docs to a few functions

* Added common exports of all files

* Added option to have acceptance buildtest use the sqs queue

- New optional environment variable ACCEPTANCE_SEND_TO_QUEUE. When set to truthy, the acceptance build test will put a test message on the sqs queue rather than run via API.

---------