### PR TITLE
Fix Version Sort Scripting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adler32"
@@ -145,9 +145,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
@@ -161,7 +161,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
@@ -242,18 +242,18 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.26"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -589,12 +589,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1147,9 +1147,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
 dependencies = [
  "jiff-static",
  "log",
@@ -1160,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1214,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libflate"
@@ -1281,9 +1281,9 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "minimal-lexical"
@@ -1293,9 +1293,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
@@ -1307,7 +1307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
 
@@ -1469,7 +1469,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1480,9 +1480,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
  "thiserror",
@@ -1491,9 +1491,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1501,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1514,18 +1514,17 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
- "once_cell",
  "pest",
  "sha2",
 ]
 
 [[package]]
 name = "pewpew"
-version = "0.5.13"
+version = "0.5.14"
 dependencies = [
  "base64 0.22.1",
  "body_reader",
@@ -1640,9 +1639,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -1675,9 +1674,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags",
 ]
@@ -1719,9 +1718,9 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustix"
@@ -1874,12 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "smallvec"
@@ -1983,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2280,9 +2276,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -2409,9 +2405,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"
@@ -2437,7 +2433,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2446,7 +2442,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -2455,14 +2460,30 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -2472,10 +2493,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2484,10 +2517,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2496,10 +2541,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2508,10 +2565,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-bindgen-rt"
@@ -2571,18 +2640,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pewpew"
-version = "0.5.13"
+version = "0.5.14"
 edition = "2018"
 default-run = "pewpew"
 publish = false

--- a/controller/components/DropFile/index.tsx
+++ b/controller/components/DropFile/index.tsx
@@ -38,7 +38,7 @@ export interface DropFileProps {
   multiple?: boolean;
 }
 
-const DropFile = ({ onDropFile, multiple = true }: DropFileProps) => {
+export const DropFile = ({ onDropFile, multiple = true }: DropFileProps) => {
   return (
     <FileDiv className="file-div">
       <Dropzone onDrop={onDropFile} multiple={multiple} >

--- a/controller/components/FilesList/index.tsx
+++ b/controller/components/FilesList/index.tsx
@@ -12,7 +12,7 @@ export interface FileListProps {
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
-const FileList = ({
+export const FilesList = ({
   files,
   onClick
 }: FileListProps) => {
@@ -25,4 +25,4 @@ const FileList = ({
   );
 };
 
-export default FileList;
+export default FilesList;

--- a/controller/components/PewPewVersions/index.tsx
+++ b/controller/components/PewPewVersions/index.tsx
@@ -1,7 +1,7 @@
 import React, { JSX } from "react";
 import { Danger } from "../Alert";
-import Div from "../Div";
-import Toaster  from "../Toaster";
+import { Div } from "../Div";
+import { Toaster }  from "../Toaster";
 import styled from "styled-components";
 
 const VersionDiv = styled(Div)`

--- a/controller/components/PewPewVersions/story.tsx
+++ b/controller/components/PewPewVersions/story.tsx
@@ -14,7 +14,7 @@ const props: VersionProps = {
     // eslint-disable-next-line no-console
     console.log("newVal: ", newVal);
   },
-  pewpewVersions: ["0.1.1", "0.1.2", "0.1.3", "0.1.4", "0.1.5", latestPewPewVersion, "0.1.6"],
+  pewpewVersions: ["0.1.1", "0.1.2", "0.1.3", "0.1.4", "0.1.5-preview1", "0.1.5", "0.1.5-preview2", "0.1.5-preview3", latestPewPewVersion, "0.1.6-preview2", "0.1.6", "0.1.6-preview1", "0.1.6-preview3"],
   latestPewPewVersion: "0.1.6",
   loading: false,
   error: false

--- a/controller/components/StartTestForm/index.tsx
+++ b/controller/components/StartTestForm/index.tsx
@@ -19,9 +19,9 @@ import {
 } from "../EnvironmentVariablesList";
 import { H1, H3 } from "../Headers";
 import { LogLevel, log } from "../../pages/api/util/log";
-import PewPewVersions, { VersionInitalProps } from "../PewPewVersions";
+import { PewPewVersions, VersionInitalProps } from "../PewPewVersions";
+import { QueueInitialProps, TestQueues } from "../TestQueues";
 import React, { JSX, useState } from "react";
-import TestQueues, { QueueInitialProps } from "../TestQueues";
 import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
 import {
   formatError,
@@ -33,11 +33,11 @@ import {
 } from "../../pages/api/util/clientutil";
 import { CheckboxButton } from "../CheckboxButton";
 import DatePicker from "react-datepicker";
-import DropFile from "../DropFile";
-import FilesList from "../FilesList";
+import { DropFile } from "../DropFile";
+import { FilesList } from "../FilesList";
 import { Line } from "rc-progress";
-import LinkButton from "../LinkButton";
-import TestInfo from "../TestInfo";
+import { LinkButton } from "../LinkButton";
+import { TestInfo } from "../TestInfo";
 import { TestStatus } from "@fs/ppaas-common/dist/types";
 import { YamlViewer } from "../YamlViewer";
 import styled from "styled-components";
@@ -160,8 +160,11 @@ export const StartTestForm = ({
   // Check if we have a previous daysOfWeek and map to turn the ones on that need to be. Otherwise everything on.
   const defaultDaysOfWeek: DayValue[] = DAYS_ARRAY.map((name: string, index: number): DayValue =>
     ({ name, value: previousTestData?.daysOfWeek ? previousTestData.daysOfWeek.includes(index) : true }));
-  const maxPewPewVersion: string = getMaxVersion(versionInitalProps.pewpewVersions);
+  const latestVersionTag: string = // First try to switch to the version that is "latest", then fall back to the max version
+    versionInitalProps.pewpewVersions.find((value) => value === versionInitalProps.latestPewPewVersion)
+    || getMaxVersion(versionInitalProps.pewpewVersions);
   const recurringTest: boolean = (previousTestData?.daysOfWeek && previousTestData?.endDate) ? true : false;
+  log("StartTestForm latestVersionTag", LogLevel.DEBUG, { latestVersionTag, recurringTest, pewpewVersion: previousTestData?.version || versionInitalProps.pewpewVersion });
   const defaultState: StartTestState = {
     yamlFile: previousTestData?.yamlFile || undefined,
     additionalFiles: previousTestData?.additionalFiles || [],
@@ -172,7 +175,7 @@ export const StartTestForm = ({
     daysOfWeek: defaultDaysOfWeek,
     allDays: defaultDaysOfWeek.every((dayOfWeek: DayValue) => dayOfWeek.value),
     queueName: previousTestData?.queueName || queueInitialProps.queueName,
-    pewpewVersion: previousTestData?.version || (recurringTest ? maxPewPewVersion : versionInitalProps.pewpewVersion),
+    pewpewVersion: previousTestData?.version || versionInitalProps.pewpewVersion || latestPewPewVersion,
     environmentVariables: previousTestData?.environmentVariables
       ? Object.entries(previousTestData.environmentVariables).map(([variableName, variableValue]: [string, string | null], index: number) => ({
         // Map these to the placeholder values
@@ -517,10 +520,12 @@ export const StartTestForm = ({
   const setRecurring = () => {
     setFormData(({ pewpewVersion, ...oldState }: StartTestState) => {
       // We always set recurringTest to true, but if the pewpewVersion is latest we need to change it
+      log("setRecurring pewpewVersion", LogLevel.DEBUG, { pewpewVersion, latestVersionTag });
       return ({
         ...oldState,
         recurringTest: true,
-        pewpewVersion: pewpewVersion === latestPewPewVersion ? maxPewPewVersion : pewpewVersion
+        // If the current selected version is "latest" change it to a fixed version
+        pewpewVersion: pewpewVersion === latestPewPewVersion ? latestVersionTag : pewpewVersion
       });
     });
   };

--- a/controller/components/StartTestForm/story.tsx
+++ b/controller/components/StartTestForm/story.tsx
@@ -50,7 +50,7 @@ const queueInitialProps: QueueInitialProps = {
 const versionInitalProps: VersionInitalProps = {
   pewpewVersion: "",
   loading: false,
-  pewpewVersions: [latestPewPewVersion, "0.5.10", "0.5.11", "0.5.12"],
+  pewpewVersions: [latestPewPewVersion, "0.5.10", "0.5.11", "0.5.12", "0.5.13-preview1", "0.6.0"],
   latestPewPewVersion: "0.5.12",
   error: false
 };

--- a/controller/components/Toaster/index.tsx
+++ b/controller/components/Toaster/index.tsx
@@ -31,7 +31,7 @@ const Container = styled(Info)`
     &.fade-out { animation: ${fadeOut} 0.3s ease-in-out forwards; }
 `;
 
-const Toaster: React.FC<ToasterProps>  = ({ id,  message, duration = 7000 }) => {
+export const Toaster: React.FC<ToasterProps>  = ({ id,  message, duration = 7000 }) => {
   useEffect(() => {
     setTimeout(() => {
       const toasterElement = document.getElementById(id);

--- a/src/README.md
+++ b/src/README.md
@@ -21,18 +21,60 @@ C:\vcpkg> set VCPKGRS_DYNAMIC=1 (or simply set it as your environment variable)
 ```
 
 ## Changelog
+### v0.5.14
+- [Bump openssl from 0.10.57 to 0.10.60](https://github.com/FamilySearch/pewpew/pull/181)
+- [Bump h2 from 0.3.21 to 0.3.24](https://github.com/FamilySearch/pewpew/pull/193)
+- [Replace actions-rs with rustup](https://github.com/FamilySearch/pewpew/pull/198)
+- [Bump mio from 0.8.10 to 0.8.11](https://github.com/FamilySearch/pewpew/pull/200)
+- [Bump h2 from 0.3.24 to 0.3.26](https://github.com/FamilySearch/pewpew/pull/216)
+- [Update Rust Dependencies 2024-05-29](https://github.com/FamilySearch/pewpew/pull/226)
+  - Moved deprecated .cargo/config to config.toml
+  - Updated base64, itertools, yansi, env_logger, brotli, serde-wasm-bindgen
+  - Moved from abandoned yaml_rust to yaml_rust2
+  - Updated body_reader and channel dependencies
+  - Updated config-wasm and hdr-histogram dependencies
+  - Fix dependency loop with ahash on itself
+- [Update rust dependencies 2024-07-18](https://github.com/FamilySearch/pewpew/pull/236)
+  - Updated dashmap to 6
+  - Fixed clippy warnings
+- [Updated Rust hyper and http](https://github.com/FamilySearch/pewpew/pull/237)
+  - Updated http to 1.0
+  - Updated hyper to 1.0
+  - Updated hyper-tls to 0.6
+  - Added hyper-util 0.1
+  - Added http-body-util 0.1
+- [Fix response status and headers](https://github.com/FamilySearch/pewpew/pull/245)
+  - Added additional logging to the response handler
+  - Fixed a bug from the hyper upgrade
+- [Bump openssl from 0.10.64 to 0.10.66](https://github.com/FamilySearch/pewpew/pull/238)
+- [Fix Rust Lint Warnings](https://github.com/FamilySearch/pewpew/pull/281)
+- [Bump openssl from 0.10.66 to 0.10.70](https://github.com/FamilySearch/pewpew/pull/289)
+- [Bump openssl from 0.10.70 to 0.10.72](https://github.com/FamilySearch/pewpew/pull/299)
+- [Bump tokio from 1.39.2 to 1.43.1](https://github.com/FamilySearch/pewpew/pull/300)
+- [Bump crossbeam-channel from 0.5.13 to 0.5.15](https://github.com/FamilySearch/pewpew/pull/301)
+- [Update rust dependencies 2025-04-16](https://github.com/FamilySearch/pewpew/pull/305)
+  - Updated itertools to 0.14
+  - Updated brotli to 7.0
+  - Updated yaml-rust2 to 0.10
+- [Update rust dependencies 2025-06-09](https://github.com/FamilySearch/pewpew/pull/315)
+  - Updated cargo deny file now that Unicode 3.0 is allowed
+  - Updated rand to 0.9 and get_random to 0.3
+  - Updated brotli to 8.0
+  - Fixed Clippy warnings
+- [Release v5.14](https://github.com/FamilySearch/pewpew/pull/318)
+
 ### v0.5.13
 Changes:
-- use IsTerminal trait (Rust 1.70.0), removing (direct) dependency on atty crate. (#130)
+- use IsTerminal trait (Rust 1.70.0), removing (direct) dependency on atty crate. (https://github.com/FamilySearch/pewpew/pull/130)
 - Added example yaml files under /examples
-- Adds skipBody CLI argument - Skips Request and Response Body in Try Output (#140) (#169)
+- Adds skipBody CLI argument - Skips Request and Response Body in Try Output (https://github.com/FamilySearch/pewpew/pull/140) (https://github.com/FamilySearch/pewpew/pull/169)
 
 Bug fixes:
-- Updated dependencies and fixed deprecations (#143)
-- Fixed the HDR Histogram build for webpack (#119)
-- Use clap derive, fixing behavior of --include flag. (#121)
-- Fix yaml loggers (#129)
-- Fix try script hang broken in 0.5.8 (#177)
+- Updated dependencies and fixed deprecations (https://github.com/FamilySearch/pewpew/pull/143)
+- Fixed the HDR Histogram build for webpack (https://github.com/FamilySearch/pewpew/pull/119)
+- Use clap derive, fixing behavior of --include flag. (https://github.com/FamilySearch/pewpew/pull/121)
+- Fix yaml loggers (https://github.com/FamilySearch/pewpew/pull/129)
+- Fix try script hang broken in 0.5.8 (https://github.com/FamilySearch/pewpew/pull/177)
 
 ### v0.5.12
 Changes:


### PR DESCRIPTION
- https://github.com/FamilySearch/pewpew/pull/321
  - Updated the Start Test Form code to use the latest tag when recurring
  - When Scheduling a recurring test, rather than grabbing the max version, use the version currently set as 'latest'

