### PR TITLE
Fix version sort scripting

### DIFF
--- a/controller/components/DropFile/index.tsx
+++ b/controller/components/DropFile/index.tsx
@@ -38,7 +38,7 @@ export interface DropFileProps {
   multiple?: boolean;
 }
 
-const DropFile = ({ onDropFile, multiple = true }: DropFileProps) => {
+export const DropFile = ({ onDropFile, multiple = true }: DropFileProps) => {
   return (
     <FileDiv className="file-div">
       <Dropzone onDrop={onDropFile} multiple={multiple} >

--- a/controller/components/FilesList/index.tsx
+++ b/controller/components/FilesList/index.tsx
@@ -12,7 +12,7 @@ export interface FileListProps {
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
-const FileList = ({
+export const FilesList = ({
   files,
   onClick
 }: FileListProps) => {
@@ -25,4 +25,4 @@ const FileList = ({
   );
 };
 
-export default FileList;
+export default FilesList;

--- a/controller/components/PewPewVersions/index.tsx
+++ b/controller/components/PewPewVersions/index.tsx
@@ -1,7 +1,7 @@
 import React, { JSX } from "react";
 import { Danger } from "../Alert";
-import Div from "../Div";
-import Toaster  from "../Toaster";
+import { Div } from "../Div";
+import { Toaster }  from "../Toaster";
 import styled from "styled-components";
 
 const VersionDiv = styled(Div)`

--- a/controller/components/PewPewVersions/story.tsx
+++ b/controller/components/PewPewVersions/story.tsx
@@ -14,7 +14,7 @@ const props: VersionProps = {
     // eslint-disable-next-line no-console
     console.log("newVal: ", newVal);
   },
-  pewpewVersions: ["0.1.1", "0.1.2", "0.1.3", "0.1.4", "0.1.5", latestPewPewVersion, "0.1.6"],
+  pewpewVersions: ["0.1.1", "0.1.2", "0.1.3", "0.1.4", "0.1.5-preview1", "0.1.5", "0.1.5-preview2", "0.1.5-preview3", latestPewPewVersion, "0.1.6-preview2", "0.1.6", "0.1.6-preview1", "0.1.6-preview3"],
   latestPewPewVersion: "0.1.6",
   loading: false,
   error: false

--- a/controller/components/StartTestForm/index.tsx
+++ b/controller/components/StartTestForm/index.tsx
@@ -19,9 +19,9 @@ import {
 } from "../EnvironmentVariablesList";
 import { H1, H3 } from "../Headers";
 import { LogLevel, log } from "../../pages/api/util/log";
-import PewPewVersions, { VersionInitalProps } from "../PewPewVersions";
+import { PewPewVersions, VersionInitalProps } from "../PewPewVersions";
+import { QueueInitialProps, TestQueues } from "../TestQueues";
 import React, { JSX, useState } from "react";
-import TestQueues, { QueueInitialProps } from "../TestQueues";
 import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
 import {
   formatError,
@@ -33,11 +33,11 @@ import {
 } from "../../pages/api/util/clientutil";
 import { CheckboxButton } from "../CheckboxButton";
 import DatePicker from "react-datepicker";
-import DropFile from "../DropFile";
-import FilesList from "../FilesList";
+import { DropFile } from "../DropFile";
+import { FilesList } from "../FilesList";
 import { Line } from "rc-progress";
-import LinkButton from "../LinkButton";
-import TestInfo from "../TestInfo";
+import { LinkButton } from "../LinkButton";
+import { TestInfo } from "../TestInfo";
 import { TestStatus } from "@fs/ppaas-common/dist/types";
 import { YamlViewer } from "../YamlViewer";
 import styled from "styled-components";
@@ -160,8 +160,11 @@ export const StartTestForm = ({
   // Check if we have a previous daysOfWeek and map to turn the ones on that need to be. Otherwise everything on.
   const defaultDaysOfWeek: DayValue[] = DAYS_ARRAY.map((name: string, index: number): DayValue =>
     ({ name, value: previousTestData?.daysOfWeek ? previousTestData.daysOfWeek.includes(index) : true }));
-  const maxPewPewVersion: string = getMaxVersion(versionInitalProps.pewpewVersions);
+  const latestVersionTag: string = // First try to switch to the version that is "latest", then fall back to the max version
+    versionInitalProps.pewpewVersions.find((value) => value === versionInitalProps.latestPewPewVersion)
+    || getMaxVersion(versionInitalProps.pewpewVersions);
   const recurringTest: boolean = (previousTestData?.daysOfWeek && previousTestData?.endDate) ? true : false;
+  log("StartTestForm latestVersionTag", LogLevel.DEBUG, { latestVersionTag, recurringTest, pewpewVersion: previousTestData?.version || versionInitalProps.pewpewVersion });
   const defaultState: StartTestState = {
     yamlFile: previousTestData?.yamlFile || undefined,
     additionalFiles: previousTestData?.additionalFiles || [],
@@ -172,7 +175,7 @@ export const StartTestForm = ({
     daysOfWeek: defaultDaysOfWeek,
     allDays: defaultDaysOfWeek.every((dayOfWeek: DayValue) => dayOfWeek.value),
     queueName: previousTestData?.queueName || queueInitialProps.queueName,
-    pewpewVersion: previousTestData?.version || (recurringTest ? maxPewPewVersion : versionInitalProps.pewpewVersion),
+    pewpewVersion: previousTestData?.version || versionInitalProps.pewpewVersion || latestPewPewVersion,
     environmentVariables: previousTestData?.environmentVariables
       ? Object.entries(previousTestData.environmentVariables).map(([variableName, variableValue]: [string, string | null], index: number) => ({
         // Map these to the placeholder values
@@ -517,10 +520,12 @@ export const StartTestForm = ({
   const setRecurring = () => {
     setFormData(({ pewpewVersion, ...oldState }: StartTestState) => {
       // We always set recurringTest to true, but if the pewpewVersion is latest we need to change it
+      log("setRecurring pewpewVersion", LogLevel.DEBUG, { pewpewVersion, latestVersionTag });
       return ({
         ...oldState,
         recurringTest: true,
-        pewpewVersion: pewpewVersion === latestPewPewVersion ? maxPewPewVersion : pewpewVersion
+        // If the current selected version is "latest" change it to a fixed version
+        pewpewVersion: pewpewVersion === latestPewPewVersion ? latestVersionTag : pewpewVersion
       });
     });
   };

--- a/controller/components/StartTestForm/story.tsx
+++ b/controller/components/StartTestForm/story.tsx
@@ -50,7 +50,7 @@ const queueInitialProps: QueueInitialProps = {
 const versionInitalProps: VersionInitalProps = {
   pewpewVersion: "",
   loading: false,
-  pewpewVersions: [latestPewPewVersion, "0.5.10", "0.5.11", "0.5.12"],
+  pewpewVersions: [latestPewPewVersion, "0.5.10", "0.5.11", "0.5.12", "0.5.13-preview1", "0.6.0"],
   latestPewPewVersion: "0.5.12",
   error: false
 };

--- a/controller/components/Toaster/index.tsx
+++ b/controller/components/Toaster/index.tsx
@@ -31,7 +31,7 @@ const Container = styled(Info)`
     &.fade-out { animation: ${fadeOut} 0.3s ease-in-out forwards; }
 `;
 
-const Toaster: React.FC<ToasterProps>  = ({ id,  message, duration = 7000 }) => {
+export const Toaster: React.FC<ToasterProps>  = ({ id,  message, duration = 7000 }) => {
   useEffect(() => {
     setTimeout(() => {
       const toasterElement = document.getElementById(id);


### PR DESCRIPTION
- Fix Version Sort Scripting
  - Updated the Start Test Form code to use the latest tag when recurring
  - When Scheduling a recurring test, rather than grabbing the max version, use the version currently set as 'latest'

