### PR TITLE
Download large file redirect

### DIFF
--- a/controller/acceptance/download.spec.ts
+++ b/controller/acceptance/download.spec.ts
@@ -35,6 +35,7 @@ describe("Download API Integration", function () {
   let resultsFile: string;
   let stdoutFile: string;
   let stderrFile: string;
+  let largeS3File: string;
   let variablesFile: string;
   let dateString: string | undefined;
   let ppaasTestId: PpaasTestId | undefined;
@@ -55,6 +56,7 @@ describe("Download API Integration", function () {
       resultsFile = uploadResult.resultsFile;
       stdoutFile = uploadResult.stdoutFile;
       stderrFile = uploadResult.stderrFile;
+      largeS3File = uploadResult.largeS3File;
       variablesFile = uploadResult.variablesFile;
       dateString = ppaasTestId.dateString;
       expectedStatus = 200;
@@ -258,7 +260,8 @@ describe("Download API Integration", function () {
     log(`GET ${testUrl} for ${fileType}`, LogLevel.DEBUG, { status: res?.status, headers: res?.headers });
     expect(res, "res").to.not.equal(undefined);
 
-    if (REDIRECT_TO_S3) {
+    // Large file always redirects
+    if (REDIRECT_TO_S3 || filename === largeS3File) {
       // Should redirect to S3 with download parameters
       expect(res.status, "status").to.equal(302);
       expect(res.headers.location, "location header").to.not.equal(undefined);
@@ -313,6 +316,12 @@ describe("Download API Integration", function () {
   it("GET /download with testId should download stderr file", async () => {
     await testFileDownload(stderrFile, "stderr");
   });
+
+  if (ACCEPTANCE_AWS_PERMISSIONS) {
+    it("GET /download with testId should download large S3 file", async () => {
+      await testFileDownload(largeS3File, "large S3");
+    });
+  }
 
   it("POST /download should respond 400 Method Not Allowed", (done: Mocha.Done) => {
     if (!testId) { done(new Error("No testId")); return; }

--- a/controller/components/TestInfo/index.tsx
+++ b/controller/components/TestInfo/index.tsx
@@ -162,7 +162,7 @@ The previous "Stop" will automatically send a "Kill" after a few minutes if pewp
       });
       const response: AxiosResponse = await axios.get(formatPageHref(API_DOWNLOAD_FORMAT(testData.testId)));
       log("onDownload response", LogLevel.DEBUG, response.data);
-      if (Array.isArray(response.data) && response.data.length >= 0 && typeof response.data[0] === "string") {
+      if (Array.isArray(response.data) && response.data.length > 0 && typeof response.data[0] === "string") {
         updateState({ downloadFiles: response.data });
         return;
       }

--- a/controller/integration/util.ts
+++ b/controller/integration/util.ts
@@ -25,6 +25,7 @@ export interface AcceptanceFiles {
   resultsFile: string;
   stdoutFile: string;
   stderrFile: string;
+  largeS3File: string;
   variablesFile: string;
 }
 
@@ -36,6 +37,7 @@ const ACCEPTANCE_FILES: AcceptanceFiles = {
   resultsFile: "stats-rmsdeletestage20240617T193912876.json",
   stdoutFile: "app-ppaas-pewpew-rmsdeletestage20240617T193912876-out.json",
   stderrFile: "app-ppaas-pewpew-rmsdeletestage20240617T193912876-error.json",
+  largeS3File: "5mb-test-file.txt",
   variablesFile: ENCRYPTED_ENVIRONMENT_VARIABLES_FILENAME
 };
 
@@ -46,6 +48,7 @@ const ACCEPTANCE_PPAASS3FILES: {
   resultsFile?: PpaasS3File;
   stdoutFile?: PpaasS3File;
   stderrFile?: PpaasS3File;
+  largeS3File?: PpaasS3File;
   variablesFile?: PpaasS3File | PpaasEncryptEnvironmentFile;
 } = {};
 

--- a/controller/src/authserver.ts
+++ b/controller/src/authserver.ts
@@ -362,7 +362,7 @@ export async function getLogoutUrl (req: NextApiRequest): Promise<string> {
 export async function authApi (req: NextApiRequest, res: NextApiResponse, requiredPermissions: AuthPermission = AuthPermission.User): Promise<AuthPermissions | undefined> {
   if (!isAuthEnabled()) {
     log("Authentication is turned off", IS_RUNNING_IN_AWS ? LogLevel.ERROR : LogLevel.WARN);
-    return { token: undefined, authPermission: TEST_AUTH_PERMISSION || AuthPermission.Admin };
+    return { token: undefined, authPermission: TEST_AUTH_PERMISSION ?? AuthPermission.Admin };
   }
 
   log(`Checking authorization for ${req.method} ${req.url}`, LogLevel.DEBUG);
@@ -484,7 +484,7 @@ export function getRefreshTokenFromCookie (ctx: GetServerSidePropsContext): stri
 export async function authPage (ctx: GetServerSidePropsContext, requiredPermissions: AuthPermission = AuthPermission.User): Promise<AuthPermissions | string> {
   if (!isAuthEnabled()) {
     log("Authentication is turned off", IS_RUNNING_IN_AWS ? LogLevel.ERROR : LogLevel.WARN);
-    return { token: undefined, authPermission: TEST_AUTH_PERMISSION || AuthPermission.Admin };
+    return { token: undefined, authPermission: TEST_AUTH_PERMISSION ?? AuthPermission.Admin };
   }
   const token: string | undefined = getTokenFromCookieOrHeader(ctx);
 

--- a/controller/src/authserver.ts
+++ b/controller/src/authserver.ts
@@ -362,7 +362,7 @@ export async function getLogoutUrl (req: NextApiRequest): Promise<string> {
 export async function authApi (req: NextApiRequest, res: NextApiResponse, requiredPermissions: AuthPermission = AuthPermission.User): Promise<AuthPermissions | undefined> {
   if (!isAuthEnabled()) {
     log("Authentication is turned off", IS_RUNNING_IN_AWS ? LogLevel.ERROR : LogLevel.WARN);
-    return { token: undefined, authPermission: AuthPermission.Admin };
+    return { token: undefined, authPermission: TEST_AUTH_PERMISSION || AuthPermission.Admin };
   }
 
   log(`Checking authorization for ${req.method} ${req.url}`, LogLevel.DEBUG);
@@ -484,7 +484,7 @@ export function getRefreshTokenFromCookie (ctx: GetServerSidePropsContext): stri
 export async function authPage (ctx: GetServerSidePropsContext, requiredPermissions: AuthPermission = AuthPermission.User): Promise<AuthPermissions | string> {
   if (!isAuthEnabled()) {
     log("Authentication is turned off", IS_RUNNING_IN_AWS ? LogLevel.ERROR : LogLevel.WARN);
-    return { token: undefined, authPermission: AuthPermission.Admin };
+    return { token: undefined, authPermission: TEST_AUTH_PERMISSION || AuthPermission.Admin };
   }
   const token: string | undefined = getTokenFromCookieOrHeader(ctx);
 


### PR DESCRIPTION
- [TEST_AUTH_PERMISSION now also affects when auth is turned off](https://github.com/FamilySearch/pewpew/commit/8633b3db1f60456fa64ada71c8c43b3d6d701f16)
- [Added code to redirect to S3 when downloading files over the max API size](https://github.com/FamilySearch/pewpew/commit/c9774e16aba05c5ab75d736429a47cb70a692e5a)
- [Added large file tests for integration and acceptance tests](https://github.com/FamilySearch/pewpew/commit/4935b159af8f4dcfdea16ba06cc7e7ecc5b73176)
  - Fixed bug in our mock response for S3 integration tests. Headers and body are now correctly set
  - Added validation of location header on 302 redirects
  - Added tests for the 413 too large logic as well as redirects on large files when downloading files
- [Fixed array size check](https://github.com/FamilySearch/pewpew/commit/3dcfbc0dd21ac4d49aa65737535f03d077b09745)
- [Switch to nullish operator](https://github.com/FamilySearch/pewpew/commit/cd4a984e72189e34afa9975644dd661810b0e1a4)

