### PR TITLE
S3 cleanup and fixes

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/ppaas-common",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Common Code for the PewPewController and PewPewAgent",
   "type": "module",
   "main": "dist/src/index.js",

--- a/common/src/ppaasteststatus.ts
+++ b/common/src/ppaasteststatus.ts
@@ -110,6 +110,10 @@ export class PpaasTestStatus implements TestStatusMessage {
     return this.ppaasTestId.s3Folder;
   }
 
+  public getYamlFile (): string {
+    return this.ppaasTestId.yamlFile;
+  }
+
   /**
    * Internal function to get the latest TestStatusMessage
    * @param ppaasTestId testId to retrieve

--- a/common/src/util/s3.ts
+++ b/common/src/util/s3.ts
@@ -42,6 +42,7 @@ export type { S3File };
 const gunzip = promisify(zlibGunzip);
 const writeFile = promisify(fsWriteFile);
 
+export const ALLOW_S3_ACL: boolean = process.env.S3_ALLOW_ACL?.toLowerCase() === "true";
 export const SHARED_ENVIRONMENT_PREFIX: string = process.env.SHARED_ENVIRONMENT_PREFIX || "s3-environment/";
 export let BUCKET_NAME: string;
 export let BUCKET_URL: string;
@@ -556,7 +557,6 @@ export async function uploadObject (file: S3File): Promise<CompleteMultipartUplo
     taggingString += (taggingString.length > 0 ? "&" : "") + formattedPair;
   }
   const params: PutObjectCommandInput = {
-    ACL: file.publicRead ? "public-read" : "authenticated-read",
     Body: file.body,
     Bucket: BUCKET_NAME,
     CacheControl: "max-age=60",
@@ -566,6 +566,9 @@ export async function uploadObject (file: S3File): Promise<CompleteMultipartUplo
     StorageClass: file.storageClass,
     Tagging: taggingString
   };
+  if (ALLOW_S3_ACL) {
+    params.ACL = file.publicRead ? "public-read" : "authenticated-read";
+  }
   try {
     log("uploadObject request", LogLevel.DEBUG, Object.assign({}, params, { Body: undefined })); // Log it without the body
     const upload = new Upload({
@@ -625,7 +628,6 @@ export async function copyObject ({ sourceFile, destinationFile, tags }: CopyObj
     taggingString += (taggingString.length > 0 ? "&" : "") + formattedPair;
   }
   const params: CopyObjectCommandInput = {
-    ACL: destinationFile.publicRead ? "public-read" : "authenticated-read",
     CopySource: `${BUCKET_NAME}/${sourceFile.key}`,
     Bucket: BUCKET_NAME,
     Key: destinationFile.key,
@@ -633,6 +635,9 @@ export async function copyObject ({ sourceFile, destinationFile, tags }: CopyObj
     TaggingDirective: tags ? "REPLACE" : "COPY",
     Tagging: tags && taggingString
   };
+  if (ALLOW_S3_ACL) {
+    params.ACL = destinationFile.publicRead ? "public-read" : "authenticated-read";
+  }
   try {
     log("copyObject request", LogLevel.DEBUG, Object.assign({}, params, { Body: undefined })); // Log it without the body
     const result: CopyObjectCommandOutput = await s3Client.send(new CopyObjectCommand(params));

--- a/controller/components/Modal/index.tsx
+++ b/controller/components/Modal/index.tsx
@@ -7,6 +7,9 @@ import React, {
   useState
 } from "react";
 import { Button } from "../LinkButton";
+import { H3 } from "../Headers";
+import type { TestData } from "../../types";
+import { TestsList } from "../TestsList";
 import styled from "styled-components";
 
 const ModalBackdrop = styled.div`
@@ -250,6 +253,24 @@ export const Modal = forwardRef(({
       </ModalActions>
     </ModalDiv>
   </ModalStyle>
+  );
+});
+
+// CompareModal component for test comparison selection
+interface TestsListModalProps {
+  tests: TestData[] | undefined;
+  onClick: (event: React.MouseEvent<HTMLButtonElement>, test: TestData) => void;
+}
+
+export const TestsListModal = forwardRef(({ tests, onClick }: TestsListModalProps, ref: Ref<ModalObject>) => {
+  return (
+    <Modal ref={ref} title="Compare With" closeText="Cancel">
+      {tests === undefined
+        ? <H3>Loading...</H3>
+        : tests.length > 0
+          ? <TestsList tests={tests} onClick={onClick}/>
+          : <p>No prior tests found</p>}
+    </Modal>
   );
 });
 

--- a/controller/components/Modal/story.tsx
+++ b/controller/components/Modal/story.tsx
@@ -1,6 +1,6 @@
 import { LogLevel, log } from "../../src/log";
 import type { Meta, StoryFn } from "@storybook/react";
-import { Modal, ModalObject, useEffectModal } from ".";
+import { Modal, ModalObject, TestsListModal, useEffectModal } from ".";
 import React, { useRef, useState } from "react";
 import TestsList, { TestListProps } from "../TestsList";
 import { Button } from "../LinkButton";
@@ -158,6 +158,125 @@ const ModalFileListLargeDemo = () => {
  );
 };
 
+const TestsListModalUndefinedDemo = () => {
+ const modalRef = useRef<ModalObject | null>(null);
+ useEffectModal(modalRef, LogLevel.INFO);
+
+ const handleClick = (event: React.MouseEvent<HTMLButtonElement>, test: TestData) => {
+   log("Test clicked", LogLevel.INFO, test);
+ };
+
+ return (
+   <div>
+     <GlobalStyle />
+     <Div>
+       Compare results with:&nbsp;<Button onClick={() => modalRef.current?.openModal()}>Prior Test</Button>
+       <TestsListModal
+         ref={modalRef}
+         tests={undefined}
+         onClick={handleClick}
+       />
+     </Div>
+   </div>
+ );
+};
+
+const TestsListModalEmptyDemo = () => {
+ const modalRef = useRef<ModalObject | null>(null);
+ useEffectModal(modalRef, LogLevel.INFO);
+ const [tests, setTests] = useState<TestData[] | undefined>(undefined);
+
+ const handleClick = (event: React.MouseEvent<HTMLButtonElement>, test: TestData) => {
+   log("Test clicked", LogLevel.INFO, test);
+ };
+
+ const handleOpenModal = () => {
+   setTests(undefined);
+   modalRef.current?.openModal();
+   setTimeout(() => {
+     setTests([]);
+   }, 1000);
+ };
+
+ return (
+   <div>
+     <GlobalStyle />
+     <Div>
+       Compare results with:&nbsp;<Button onClick={handleOpenModal}>Prior Test</Button>
+       <TestsListModal
+         ref={modalRef}
+         tests={tests}
+         onClick={handleClick}
+       />
+     </Div>
+   </div>
+ );
+};
+
+const TestsListModalLoadedDemo = () => {
+ const modalRef = useRef<ModalObject | null>(null);
+ useEffectModal(modalRef, LogLevel.INFO);
+ const [tests, setTests] = useState<TestData[] | undefined>(undefined);
+
+ const handleClick = (event: React.MouseEvent<HTMLButtonElement>, test: TestData) => {
+   log("Test clicked", LogLevel.INFO, test);
+ };
+
+ const handleOpenModal = () => {
+   setTests(undefined);
+   modalRef.current?.openModal();
+   setTimeout(() => {
+     setTests(propsLoaded.tests);
+   }, 1000);
+ };
+
+ return (
+   <div>
+     <GlobalStyle />
+     <Div>
+       Compare results with:&nbsp;<Button onClick={handleOpenModal}>Prior Test</Button>
+       <TestsListModal
+         ref={modalRef}
+         tests={tests}
+         onClick={handleClick}
+       />
+     </Div>
+   </div>
+ );
+};
+
+const TestsListModalLoadedLargeDemo = () => {
+ const modalRef = useRef<ModalObject | null>(null);
+ useEffectModal(modalRef, LogLevel.INFO);
+ const [tests, setTests] = useState<TestData[] | undefined>(undefined);
+
+ const handleClick = (event: React.MouseEvent<HTMLButtonElement>, test: TestData) => {
+   log("Test clicked", LogLevel.INFO, test);
+ };
+
+ const handleOpenModal = () => {
+   setTests(undefined);
+   modalRef.current?.openModal();
+   setTimeout(() => {
+     setTests(propsLoadedLarge.tests);
+   }, 1000);
+ };
+
+ return (
+   <div>
+     <GlobalStyle />
+     <Div>
+       Compare results with:&nbsp;<Button onClick={handleOpenModal}>Prior Test</Button>
+       <TestsListModal
+         ref={modalRef}
+         tests={tests}
+         onClick={handleClick}
+       />
+     </Div>
+   </div>
+ );
+};
+
 
 export default {
   title: "Modal"
@@ -173,4 +292,20 @@ export const FileList: StoryFn = () => (
 
 export const FileListLarge: StoryFn = () => (
   <ModalFileListLargeDemo/>
+);
+
+export const TestsListModalUndefined: StoryFn = () => (
+  <TestsListModalUndefinedDemo/>
+);
+
+export const TestsListModalEmpty: StoryFn = () => (
+  <TestsListModalEmptyDemo/>
+);
+
+export const TestsListModalLoaded: StoryFn = () => (
+  <TestsListModalLoadedDemo/>
+);
+
+export const TestsListModalLoadedLarge: StoryFn = () => (
+  <TestsListModalLoadedLargeDemo/>
 );

--- a/controller/src/testscheduler.ts
+++ b/controller/src/testscheduler.ts
@@ -41,6 +41,7 @@ import { PpaasEncryptS3File } from "./ppaasencrypts3file";
 const { sleep } = util;
 const TEST_SCHEDULER_POLL_INTERVAL_MS: number = parseInt(process.env.TEST_SCHEDULER_POLL_INTERVAL_MS || "0", 10) || 60000;
 const RUN_HISTORICAL_SEARCH: boolean = process.env.RUN_HISTORICAL_SEARCH?.toLowerCase() === "true";
+const HISTORICAL_SEARCH_START_DELAY_MINUTES: number = parseInt(process.env.HISTORICAL_SEARCH_START_DELAY_MINUTES || "0", 10) || 30;
 const HISTORICAL_SEARCH_MAX_FILES: number = parseInt(process.env.HISTORICAL_SEARCH_MAX_FILES || "0", 10) || 100000;
 const RUN_HISTORICAL_DELETE: boolean = process.env.RUN_HISTORICAL_DELETE?.toLowerCase() === "true";
 const DELETE_OLD_FILES_DAYS: number = parseInt(process.env.DELETE_OLD_FILES_DAYS || "0") || 365;
@@ -802,6 +803,13 @@ export class TestScheduler implements TestSchedulerItem {
     try {
       // Load existing ones
       await TestScheduler.loadHistoricalFromS3();
+      // Don't start right away, let the controller become healthy first
+      const searchStart: number = Date.now() + (IS_RUNNING_IN_AWS ? (HISTORICAL_SEARCH_START_DELAY_MINUTES * 60000) : 0);
+      if (searchStart > Date.now()) {
+        const delay = searchStart - Date.now();
+        log("runHistoricalSearch: start: " + new Date(searchStart), LogLevel.DEBUG, { delay, nextLoop: searchStart });
+        await sleep(delay);
+      }
       log("Starting Test Historical Search", LogLevel.DEBUG, { sizeBefore: TestScheduler.historicalTests!.size });
       // Create an ignore list
       const ignoreList: string[] = Array.from((TestScheduler.historicalTests || new Map<string, EventInput>()).keys());
@@ -820,7 +828,7 @@ export class TestScheduler implements TestSchedulerItem {
             }
             const testId: string = ppaasTestStatus.getTestId();
             if (ppaasTestStatus.status === TestStatus.Failed || ppaasTestStatus.status === TestStatus.Finished) {
-              const yamlFile = PpaasTestId.getFromTestId(testId).yamlFile;
+              const yamlFile = ppaasTestStatus.getYamlFile();
               const eventInput: EventInput = createHistoricalEvent(testId, yamlFile, ppaasTestStatus.startTime, ppaasTestStatus.endTime, ppaasTestStatus.status);
               log("Found Historical Test " + testId, LogLevel.DEBUG, eventInput);
               TestScheduler.historicalTests!.set(testId, eventInput);

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
     },
     "common": {
       "name": "@fs/ppaas-common",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.363.0",
         "@aws-sdk/client-sqs": "^3.363.0",


### PR DESCRIPTION
- [Added fix for ACL issues in some S3 buckets](https://github.com/FamilySearch/pewpew/commit/899b5a0dc2ebf01e308852d91843db8529be5767)
  - Unless explicitly turned on, S3 buckets do not allow setting the ACL on objects.
  - Only if ALLOW_S3_ACL environment variable is set to 'true' will we set the object ACLs.
- [Added cleanup call if sendTest fails on postTest](https://github.com/FamilySearch/pewpew/commit/6a842e96d57c23b7d8ea1bfe9fa2d541b55be743)
  - If we have an error sending the test to the SQS queue, we don't clean-up S3 and scheduled tests will keep retrying and keep creating hundreds of S3 files.
  - If the sendTest to the SQS queue fails, we'll delete the files from S3.
- [Added a delay to the runHistoricalSearch loop on startup](https://github.com/FamilySearch/pewpew/commit/7144b7593039a04ae24d3ae05c286a3b86fe479c)
  - We were having issues with healthchecks failing because of the load of the historical search and others on start-up
- [Improvements to the TestResultsCompare](https://github.com/FamilySearch/pewpew/commit/f45e6738165a5a81ffca89209b6dbd5d88ad3e58)
  - Moved the Modal of the list of tests to compare to a separate component under Modal called TestsListsModal. Added Storybook for the new component
  - Changed the TestResults component to use the new TestsListModal
  - Added a 'Loading' message to the TestsListModal before loaded
  - Modified the onPriorTestSearch() to load the modal immediately on click and display the Loading message
  - Added code to onPriorTestSearch() to close the modal on error (when it's displayed)
- [Updated common version](https://github.com/FamilySearch/pewpew/commit/ca70bc670cf2e7143d9ec139bf72f8394e7f32f2)


Integration Tests:
<img width="886" height="1252" alt="image" src="https://github.com/user-attachments/assets/23dc77d3-2d84-4cca-b897-16dfe677c83f" />
<img width="890" height="1227" alt="image" src="https://github.com/user-attachments/assets/77edb6f7-23c6-4730-8e4d-6378fe07722e" />
