### PR TITLE
Pre-cache recent tests

### DIFF
--- a/controller/integration/testscheduler.spec.ts
+++ b/controller/integration/testscheduler.spec.ts
@@ -26,6 +26,7 @@ import { EventInput } from "@fullcalendar/core";
 import { expect } from "chai";
 import { getHourMinuteFromTimestamp } from "../src/clientutil";
 import { getPewPewVersionsInS3 } from "../src/pewpew";
+import { getRecentTests } from "../src/testmanager";
 
 const sleep = util.sleep;
 
@@ -113,6 +114,10 @@ class TestSchedulerIntegration extends TestScheduler {
 
   public static async saveHistoricalToS3 (): Promise<void> {
     return await TestScheduler.saveHistoricalToS3();
+  }
+
+  public static async populateCacheFromHistorical (days: number): Promise<void> {
+    return await TestScheduler.populateCacheFromHistorical(days);
   }
 }
 
@@ -681,6 +686,31 @@ describe("TestScheduler Integration", () => {
       done();
     })
     .catch((error) => done(error));
+  });
+
+  describe("populateCacheFromHistorical", () => {
+    before(async () => {
+      const historicalTests: Map<string, EventInput> = new Map<string, EventInput>();
+      historicalTests.set(historicalEvent.id as string, historicalEvent);
+      TestSchedulerIntegration.setHistoricalTests(historicalTests);
+      await TestSchedulerIntegration.saveHistoricalToS3();
+    });
+
+    afterEach(() => {
+      getRecentTests().clear();
+    });
+
+    it("should populate recent cache from historical data with real S3 status", async () => {
+      getRecentTests().clear();
+      await TestSchedulerIntegration.populateCacheFromHistorical(7);
+      const recentTests = getRecentTests();
+      expect(recentTests.has(historicalTestId.testId), "recentTests.has(historicalTestId)").to.equal(true);
+      const storedTest = recentTests.get(historicalTestId.testId)!;
+      expect(storedTest.testId, "storedTest.testId").to.equal(historicalTestId.testId);
+      expect(storedTest.startTime, "storedTest.startTime").to.be.greaterThan(0);
+      // Status should be loaded from PpaasTestStatus written in before()
+      expect(storedTest.status, "storedTest.status").to.equal(TestStatus.Finished);
+    });
   });
 
   // Must be run last since we'll delete the files

--- a/controller/package.json
+++ b/controller/package.json
@@ -34,11 +34,11 @@
     "node": "24"
   },
   "overrides": {
-    "eslint": "^10.0.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0"
+    "eslint": "$eslint",
+    "react": "$react",
+    "react-dom": "$react-dom",
+    "@types/react": "$@types/react",
+    "@types/react-dom": "$@types/react-dom"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.363.0",

--- a/controller/src/testmanager.ts
+++ b/controller/src/testmanager.ts
@@ -613,6 +613,13 @@ export abstract class TestManager {
     return foundTest ? ({ testData: foundTest, cacheLocation }) : undefined;
   }
 
+  // Adds a list of tests to the recent cache, oldest first so newest survive eviction
+  public static async addRecentTests (tests: StoredTestData[]): Promise<void> {
+    for (const test of tests) {
+      await this.addToStoredList(test, CacheLocation.Recent);
+    }
+  }
+
   // Returns removed element or none if we haven't maxed out
   protected static async addToStoredList (newData: StoredTestData, cacheLocation: CacheLocation): Promise<StoredTestData | undefined> {
     log(`addToStoredTest testId (${newData.testId})`, LogLevel.DEBUG, { newData, cacheLocation });

--- a/controller/src/testscheduler.ts
+++ b/controller/src/testscheduler.ts
@@ -28,11 +28,16 @@ import {
   PpaasTestStatus,
   TestMessage,
   TestStatus,
+  TestStatusMessage,
   log,
   s3,
   util
 } from "@fs/ppaas-common";
-import { TestManager, defaultRecurringFileTags } from "./testmanager";
+import {
+  MAX_SAVED_TESTS_RECENT,
+  TestManager,
+  defaultRecurringFileTags
+} from "./testmanager";
 import { formatError, getHourMinuteFromTimestamp } from "./clientutil";
 import type { EventInput } from "@fullcalendar/core";
 import { IS_RUNNING_IN_AWS } from "./authclient";
@@ -44,6 +49,7 @@ const RUN_HISTORICAL_SEARCH: boolean = process.env.RUN_HISTORICAL_SEARCH?.toLowe
 const HISTORICAL_SEARCH_START_DELAY_MINUTES: number = parseInt(process.env.HISTORICAL_SEARCH_START_DELAY_MINUTES || "0", 10) || 30;
 const HISTORICAL_SEARCH_MAX_FILES: number = parseInt(process.env.HISTORICAL_SEARCH_MAX_FILES || "0", 10) || 100000;
 const RUN_HISTORICAL_DELETE: boolean = process.env.RUN_HISTORICAL_DELETE?.toLowerCase() === "true";
+const POPULATE_CACHE_FROM_HISTORICAL: number | undefined = parseInt(process.env.POPULATE_CACHE_FROM_HISTORICAL || "0", 10) || undefined;
 const DELETE_OLD_FILES_DAYS: number = parseInt(process.env.DELETE_OLD_FILES_DAYS || "0") || 365;
 const ONE_DAY: number = 24 * 60 * 60000;
 export const AUTH_PERMISSIONS_SCHEDULER: AuthPermissions = { authPermission: AuthPermission.Admin, token: "startTestSchedulerLoop", userId: "controller" };
@@ -382,6 +388,9 @@ export class TestScheduler implements TestSchedulerItem {
     if (RUN_HISTORICAL_SEARCH) {
       TestScheduler.runHistoricalSearch().catch(() => { /* already logs error, swallow */ });
     }
+    if (POPULATE_CACHE_FROM_HISTORICAL) {
+      TestScheduler.populateCacheFromHistorical(POPULATE_CACHE_FROM_HISTORICAL).catch(() => { /* already logs error, swallow */ });
+    }
     if (RUN_HISTORICAL_DELETE) {
       // Start background task to delete old files
       (async () => {
@@ -676,6 +685,18 @@ export class TestScheduler implements TestSchedulerItem {
       TestScheduler.scheduledTests!.delete(testId);
       log(`Scheduled Load Test removed testId ${testId} by userId ${authPermissions.userId}`, LogLevel.INFO, { ...getLogAuthPermissions(authPermissions), testId });
       TestScheduler.updateNextStart();
+      if (deleteS3Files) {
+        // Delete schedule needs to delete the files in S3 too.
+        await s3.listFiles({ s3Folder }).then((s3Files) =>
+          Promise.allSettled(
+            s3Files.filter((s3File) => s3File.Key)
+            .map((s3File) => s3.deleteObject(s3File.Key!)
+              .then(() => log(`removeTest ${testId} deleted ${s3File.Key}`, LogLevel.INFO, { s3Folder }))
+              .catch((error) => log(`removeTest ${testId} failed to delete s3 file ${s3File.Key}`, LogLevel.WARN, error, { s3Folder, s3File }))
+            )
+          )
+        ).catch((error) => log(`removeTest ${testId} failed to find s3 files`, LogLevel.WARN, error));
+      }
       await TestScheduler.saveTestsToS3().catch(() => {/* noop logs itself */});
       try {
         if (deleteS3Files) {
@@ -883,6 +904,66 @@ export class TestScheduler implements TestSchedulerItem {
       log("Error running Historical Delete", LogLevel.WARN, error, { deletedCount });
       throw error; // Throw for testing, but the loop will catch and noop
     }
+  }
+
+  protected static async populateCacheFromHistorical (days: number): Promise<void> {
+    log("TestScheduler: populateCacheFromHistorical", LogLevel.INFO, { days });
+    try {
+      await TestScheduler.loadHistoricalFromS3();
+    } catch (error) {
+      log("TestScheduler: populateCacheFromHistorical could not load historical from S3", LogLevel.WARN, error);
+      return;
+    }
+    if (!TestScheduler.historicalTests) {
+      return;
+    }
+    const cutoff = Date.now() - (days * ONE_DAY);
+    const filteredItems = Array.from(TestScheduler.historicalTests.entries())
+      .filter(([, eventInput]) => typeof eventInput.start === "number" && eventInput.start >= cutoff)
+      .sort(([, a], [, b]) => (a.start as number) - (b.start as number))
+      .slice(-MAX_SAVED_TESTS_RECENT);
+    log("TestScheduler: populateCacheFromHistorical filtered items", LogLevel.INFO, { count: filteredItems.length, days });
+    log("TestScheduler: populateCacheFromHistorical filtered items", LogLevel.DEBUG, { days, filteredItems });
+    const storedTests: StoredTestData[] = [];
+    for (const [testId, eventInput] of filteredItems) {
+      try {
+        const ppaasTestId = PpaasTestId.getFromTestId(testId);
+        const status: TestStatus = eventInput.color === "red" ? TestStatus.Failed
+          : (eventInput.color === "green" ? TestStatus.Finished : TestStatus.Unknown);
+        const startTime = eventInput.start as number;
+        const storedTest: StoredTestData = {
+          testId,
+          s3Folder: ppaasTestId.s3Folder,
+          startTime,
+          endTime: eventInput.end as number,
+          status,
+          lastUpdated: new Date(startTime)
+        };
+        if (status === TestStatus.Unknown) {
+          try {
+            const ppaasTestStatus: PpaasTestStatus | undefined = await PpaasTestStatus.getStatus(ppaasTestId);
+            if (ppaasTestStatus) {
+              const { resultsFilename, ...testStatusParts }: TestStatusMessage = ppaasTestStatus.getTestStatusMessage();
+              Object.assign(storedTest, testStatusParts);
+              storedTest.ppaasTestStatus = ppaasTestStatus;
+              storedTest.lastUpdated = ppaasTestStatus.getLastModifiedRemote();
+              storedTest.lastChecked = new Date();
+              storedTest.resultsFileLocation = resultsFilename.map((resultsFile: string) =>
+                new PpaasS3File({ filename: resultsFile, s3Folder: ppaasTestId.s3Folder, localDirectory }).remoteUrl
+              );
+            }
+          } catch (error) {
+            log(`TestScheduler: populateCacheFromHistorical could not load PpaasTestStatus for ${testId}`, LogLevel.WARN, error);
+          }
+        }
+        if (storedTest.status === TestStatus.Finished || storedTest.status === TestStatus.Failed) {
+          storedTests.push(storedTest);
+        }
+      } catch (error) {
+        log(`TestScheduler: populateCacheFromHistorical error adding testId ${testId}`, LogLevel.WARN, error);
+      }
+    }
+    await TestManager.addRecentTests(storedTests);
   }
 
   protected static async loadHistoricalFromS3 (force?: boolean): Promise<void> {

--- a/controller/test/testmanager.spec.ts
+++ b/controller/test/testmanager.spec.ts
@@ -1076,6 +1076,75 @@ describe("TestManager", () => {
     });
   });
 
+  describe("addRecentTests", () => {
+    beforeEach(() => {
+      TestManagerIntegration.clearAllMaps();
+      PpaasTestStatusIntegration.getStatusResult = false;
+    });
+
+    it("should add nothing if empty array", async () => {
+      await TestManager.addRecentTests([]);
+      expect(TestManagerIntegration.recentTestsInt.size, "recentTestsInt.size").to.equal(0);
+    });
+
+    it("should add a single test to recent", async () => {
+      const test = createStoredTestData("addRecentTests");
+      await TestManager.addRecentTests([test]);
+      expect(TestManagerIntegration.recentTestsInt.has(test.testId), "recentTestsInt.has").to.equal(true);
+      expect(TestManagerIntegration.recentTestsInt.size, "recentTestsInt.size").to.equal(1);
+    });
+
+    it("should add multiple tests to recent", async () => {
+      const test1 = createStoredTestData("addRecentTests", 1);
+      const test2 = createStoredTestData("addRecentTests", 2);
+      const test3 = createStoredTestData("addRecentTests", 3);
+      await TestManager.addRecentTests([test1, test2, test3]);
+      expect(TestManagerIntegration.recentTestsInt.has(test1.testId), "has test1").to.equal(true);
+      expect(TestManagerIntegration.recentTestsInt.has(test2.testId), "has test2").to.equal(true);
+      expect(TestManagerIntegration.recentTestsInt.has(test3.testId), "has test3").to.equal(true);
+      expect(TestManagerIntegration.recentTestsInt.size, "recentTestsInt.size").to.equal(3);
+    });
+
+    it("should evict oldest when adding past MAX_SAVED_TESTS_RECENT", async () => {
+      const tests: StoredTestData[] = [];
+      for (let i = 0; i < MAX_SAVED_TESTS_RECENT + 1; i++) {
+        tests.push(createStoredTestData("addRecentTests", i));
+      }
+      await TestManager.addRecentTests(tests);
+      // Size should be capped
+      expect(TestManagerIntegration.recentTestsInt.size, "recentTestsInt.size").to.equal(MAX_SAVED_TESTS_RECENT);
+      // Last test (newest) should be present
+      expect(TestManagerIntegration.recentTestsInt.has(tests[MAX_SAVED_TESTS_RECENT].testId), "newest present").to.equal(true);
+      // First test (oldest inserted) should have been evicted
+      expect(TestManagerIntegration.recentTestsInt.has(tests[0].testId), "oldest evicted").to.equal(false);
+    });
+
+    it("should preserve newest tests when adding many more than MAX_SAVED_TESTS_RECENT", async () => {
+      const extra = 3;
+      const tests: StoredTestData[] = [];
+      for (let i = 0; i < MAX_SAVED_TESTS_RECENT + extra; i++) {
+        tests.push(createStoredTestData("addRecentTests", i));
+      }
+      await TestManager.addRecentTests(tests);
+      expect(TestManagerIntegration.recentTestsInt.size, "recentTestsInt.size").to.equal(MAX_SAVED_TESTS_RECENT);
+      // Newest tests should be present
+      for (let i = extra; i < MAX_SAVED_TESTS_RECENT + extra; i++) {
+        expect(TestManagerIntegration.recentTestsInt.has(tests[i].testId), `tests[${i}] present`).to.equal(true);
+      }
+      // Oldest (first `extra`) should be evicted
+      for (let i = 0; i < extra; i++) {
+        expect(TestManagerIntegration.recentTestsInt.has(tests[i].testId), `tests[${i}] evicted`).to.equal(false);
+      }
+    });
+
+    it("should not duplicate a test already in recent", async () => {
+      const test = createStoredTestData("addRecentTests");
+      await TestManager.addRecentTests([test]);
+      await TestManager.addRecentTests([test]);
+      expect(TestManagerIntegration.recentTestsInt.size, "recentTestsInt.size").to.equal(1);
+    });
+  });
+
   describe("getLatestDateTime", () => {
     let storedTestData: StoredTestData;
     let errorCounter = 0;

--- a/controller/test/testscheduler.spec.ts
+++ b/controller/test/testscheduler.spec.ts
@@ -5,6 +5,7 @@ import {
   ErrorResponse,
   ScheduledTestData,
   ScheduledTestRecurrence,
+  StoredTestData,
   TestData,
   TestDataResponse,
   TestManagerError
@@ -15,9 +16,11 @@ import {
   PpaasTestStatus,
   TestMessage,
   TestStatus,
+  TestStatusMessage,
   log,
   util
 } from "@fs/ppaas-common";
+import { MAX_SAVED_TESTS_RECENT, getRecentTests } from "../src/testmanager";
 import {
   TestScheduler,
   TestSchedulerItem,
@@ -25,6 +28,14 @@ import {
   getTestsToRun
 } from "../src/testscheduler";
 import { getHourMinuteFromTimestamp, latestPewPewVersion } from "../src/clientutil";
+import {
+  mockGetObject,
+  mockGetObjectTagging,
+  mockListObject,
+  mockListObjects,
+  mockS3,
+  resetMockS3
+} from "./mock";
 import { EventInput } from "@fullcalendar/core";
 import { expect } from "chai";
 
@@ -142,6 +153,23 @@ export class TestSchedulerIntegration extends TestScheduler {
   /** public so we can call it for testing */
   public static runHistoricalDelete (deleteOldFilesDays?: number) {
     return TestScheduler.runHistoricalDelete(deleteOldFilesDays);
+  }
+
+  /** public so we can call it for testing */
+  public static populateCacheFromHistorical (days: number): Promise<void> {
+    return TestScheduler.populateCacheFromHistorical(days);
+  }
+
+  /** Calls populateCacheFromHistorical with loadHistoricalFromS3 overridden to throw */
+  public static async populateCacheFromHistoricalWithLoadError (days: number): Promise<void> {
+    const originalLoad = TestScheduler.loadHistoricalFromS3;
+    // eslint-disable-next-line require-await
+    TestScheduler.loadHistoricalFromS3 = async () => { throw new Error("simulated S3 error"); };
+    try {
+      return await TestScheduler.populateCacheFromHistorical(days);
+    } finally {
+      TestScheduler.loadHistoricalFromS3 = originalLoad;
+    }
   }
 }
 
@@ -1357,6 +1385,236 @@ describe("TestScheduler", () => {
         expect(historicalTests.size, "historicalTests.size").to.equal(2);
       } catch (error) {
         log("should remove old, but not new error", LogLevel.ERROR, error);
+        throw error;
+      }
+    });
+  });
+
+  describe("populateCacheFromHistorical", () => {
+    before(() => {
+      mockS3();
+    });
+
+    after(() => {
+      resetMockS3();
+    });
+
+    beforeEach(() => {
+      // Clear historical and recent caches before each test
+      const historicalTests: Map<string, EventInput> = TestSchedulerIntegration.getHistoricalTests();
+      historicalTests.clear();
+      getRecentTests().clear();
+      // Default: S3 returns no status file found for PpaasTestStatus.getStatus
+      mockListObjects([]);
+    });
+
+    it("should add nothing if historicalTests is empty", async () => {
+      try {
+        await TestSchedulerIntegration.populateCacheFromHistorical(7);
+        expect(getRecentTests().size, "recentTests.size").to.equal(0);
+      } catch (error) {
+        log("should add nothing if historicalTests is empty error", LogLevel.ERROR, error);
+        throw error;
+      }
+    });
+
+    it("should add test within days range to recent cache", async () => {
+      try {
+        const startTime = Date.now() - ONE_HOUR;
+        const endTime = Date.now();
+        await TestSchedulerIntegration.addHistoricalTest(testId, yamlFile, startTime, endTime, TestStatus.Finished);
+        await TestSchedulerIntegration.populateCacheFromHistorical(7);
+        const recentTests = getRecentTests();
+        expect(recentTests.size, "recentTests.size").to.equal(1);
+        expect(recentTests.has(testId), "recentTests.has testId").to.equal(true);
+      } catch (error) {
+        log("should add test within days range error", LogLevel.ERROR, error);
+        throw error;
+      }
+    });
+
+    it("should not add test older than days cutoff", async () => {
+      try {
+        const startTime = Date.now() - (8 * ONE_DAY);
+        const endTime = Date.now() - (8 * ONE_DAY) + ONE_HOUR;
+        await TestSchedulerIntegration.addHistoricalTest(testId, yamlFile, startTime, endTime, TestStatus.Finished);
+        await TestSchedulerIntegration.populateCacheFromHistorical(7);
+        expect(getRecentTests().size, "recentTests.size").to.equal(0);
+      } catch (error) {
+        log("should not add test older than days cutoff error", LogLevel.ERROR, error);
+        throw error;
+      }
+    });
+
+    it("should filter old tests but keep recent ones", async () => {
+      try {
+        const recentStart = Date.now() - ONE_HOUR;
+        const oldStart = Date.now() - (8 * ONE_DAY);
+        const recentTestId = PpaasTestId.makeTestId(yamlFile).testId;
+        await util.sleep(5); // Ensure different testIds
+        const oldTestId = PpaasTestId.makeTestId(yamlFile).testId;
+        await TestSchedulerIntegration.addHistoricalTest(recentTestId, yamlFile, recentStart, recentStart + ONE_HOUR, TestStatus.Finished);
+        await TestSchedulerIntegration.addHistoricalTest(oldTestId, yamlFile, oldStart, oldStart + ONE_HOUR, TestStatus.Finished);
+        await TestSchedulerIntegration.populateCacheFromHistorical(7);
+        const recentTests = getRecentTests();
+        expect(recentTests.size, "recentTests.size").to.equal(1);
+        expect(recentTests.has(recentTestId), "recentTests.has recentTestId").to.equal(true);
+        expect(recentTests.has(oldTestId), "recentTests.has oldTestId").to.equal(false);
+      } catch (error) {
+        log("should filter old tests but keep recent ones error", LogLevel.ERROR, error);
+        throw error;
+      }
+    });
+
+    it("should map red color to Failed status", async () => {
+      try {
+        const startTime = Date.now() - ONE_HOUR;
+        await TestSchedulerIntegration.addHistoricalTest(testId, yamlFile, startTime, Date.now(), TestStatus.Failed);
+        await TestSchedulerIntegration.populateCacheFromHistorical(7);
+        const found: StoredTestData | undefined = getRecentTests().get(testId);
+        expect(found, "found").to.not.equal(undefined);
+        expect(found?.status, "status").to.equal(TestStatus.Failed);
+      } catch (error) {
+        log("should map red color to Failed status error", LogLevel.ERROR, error);
+        throw error;
+      }
+    });
+
+    it("should map green color to Finished status", async () => {
+      try {
+        const startTime = Date.now() - ONE_HOUR;
+        await TestSchedulerIntegration.addHistoricalTest(testId, yamlFile, startTime, Date.now(), TestStatus.Finished);
+        await TestSchedulerIntegration.populateCacheFromHistorical(7);
+        const found: StoredTestData | undefined = getRecentTests().get(testId);
+        expect(found, "found").to.not.equal(undefined);
+        expect(found?.status, "status").to.equal(TestStatus.Finished);
+      } catch (error) {
+        log("should map green color to Finished status error", LogLevel.ERROR, error);
+        throw error;
+      }
+    });
+
+    it("should not add Unknown status entries to recent cache", async () => {
+      try {
+        const startTime = Date.now() - ONE_HOUR;
+        // TestStatus.Running produces "purple" color; mockListObjects([]) in beforeEach means getStatus returns undefined
+        await TestSchedulerIntegration.addHistoricalTest(testId, yamlFile, startTime, Date.now(), TestStatus.Running);
+        await TestSchedulerIntegration.populateCacheFromHistorical(7);
+        // Unknown status (no S3 result) should NOT be added to recent tests
+        expect(getRecentTests().has(testId), "recentTests.has testId").to.equal(false);
+      } catch (error) {
+        log("should not add Unknown status entries to recent cache error", LogLevel.ERROR, error);
+        throw error;
+      }
+    });
+
+    it("should load actual status from S3 for unknown color entries", async () => {
+      try {
+        const startTime = Date.now() - ONE_HOUR;
+        const endTime = Date.now();
+        // TestStatus.Running produces "purple" color
+        await TestSchedulerIntegration.addHistoricalTest(testId, yamlFile, startTime, endTime, TestStatus.Running);
+        // Mock S3 to return a status file with Failed status
+        const testStatusMessage: TestStatusMessage = {
+          startTime,
+          endTime,
+          resultsFilename: [],
+          status: TestStatus.Failed,
+          errors: ["test error from S3"]
+        };
+        mockListObject({ filename: `${testId}.info`, folder: ppaasTestId.s3Folder });
+        mockGetObject(JSON.stringify(testStatusMessage));
+        mockGetObjectTagging(undefined);
+        await TestSchedulerIntegration.populateCacheFromHistorical(7);
+        const found: StoredTestData | undefined = getRecentTests().get(testId);
+        expect(found, "found").to.not.equal(undefined);
+        expect(found?.status, "status from S3").to.equal(TestStatus.Failed);
+        expect(found?.ppaasTestStatus, "ppaasTestStatus populated").to.not.equal(undefined);
+      } catch (error) {
+        log("should load actual status from S3 for unknown color entries error", LogLevel.ERROR, error);
+        throw error;
+      }
+    });
+
+    it("should not add entry when S3 returns non-terminal status for unknown color", async () => {
+      try {
+        const startTime = Date.now() - ONE_HOUR;
+        const endTime = Date.now();
+        // TestStatus.Running produces "purple" color
+        await TestSchedulerIntegration.addHistoricalTest(testId, yamlFile, startTime, endTime, TestStatus.Running);
+        // Mock S3 to return a status file with Created status (non-terminal)
+        const testStatusMessage: TestStatusMessage = {
+          startTime,
+          endTime,
+          resultsFilename: [],
+          status: TestStatus.Created,
+          errors: []
+        };
+        mockListObject({ filename: `${testId}.info`, folder: ppaasTestId.s3Folder });
+        mockGetObject(JSON.stringify(testStatusMessage));
+        mockGetObjectTagging(undefined);
+        await TestSchedulerIntegration.populateCacheFromHistorical(7);
+        // Created status is not Finished or Failed, so should NOT be added
+        expect(getRecentTests().has(testId), "recentTests.has testId").to.equal(false);
+      } catch (error) {
+        log("should not add entry when S3 returns non-terminal status error", LogLevel.ERROR, error);
+        throw error;
+      }
+    });
+
+    it("should skip invalid testId entries without throwing", async () => {
+      try {
+        const historicalTests: Map<string, EventInput> = TestSchedulerIntegration.getHistoricalTests();
+        const startTime = Date.now() - ONE_HOUR;
+        // Add an invalid testId that PpaasTestId.getFromTestId will reject
+        historicalTests.set("invalid-test-id", { start: startTime, end: Date.now(), color: "green" });
+        // Also add a valid one
+        await TestSchedulerIntegration.addHistoricalTest(testId, yamlFile, startTime, Date.now(), TestStatus.Finished);
+        await TestSchedulerIntegration.populateCacheFromHistorical(7);
+        // Only the valid one should be added
+        const recentTests = getRecentTests();
+        expect(recentTests.has(testId), "recentTests.has valid testId").to.equal(true);
+        expect(recentTests.has("invalid-test-id"), "recentTests.has invalid").to.equal(false);
+      } catch (error) {
+        log("should skip invalid testId entries error", LogLevel.ERROR, error);
+        throw error;
+      }
+    });
+
+    it("should only keep the most recent MAX_SAVED_TESTS_RECENT items", async () => {
+      try {
+        const historicalTests: Map<string, EventInput> = TestSchedulerIntegration.getHistoricalTests();
+        const now = Date.now();
+        const testIds: string[] = [];
+        // Add MAX+2 tests with different start times
+        for (let i = 0; i < MAX_SAVED_TESTS_RECENT + 2; i++) {
+          await util.sleep(5); // Ensure unique testIds
+          const id = PpaasTestId.makeTestId(yamlFile).testId;
+          testIds.push(id);
+          const startTime = now - ((MAX_SAVED_TESTS_RECENT + 2 - i) * ONE_HOUR);
+          historicalTests.set(id, { start: startTime, end: startTime + ONE_HOUR, color: "green" });
+        }
+        await TestSchedulerIntegration.populateCacheFromHistorical(30);
+        const recentTests = getRecentTests();
+        expect(recentTests.size, "recentTests.size").to.equal(MAX_SAVED_TESTS_RECENT);
+        // The 2 oldest should have been sliced off (populateCacheFromHistorical takes last N)
+        expect(recentTests.has(testIds[0]), "oldest should be absent").to.equal(false);
+        expect(recentTests.has(testIds[1]), "second oldest should be absent").to.equal(false);
+        // The newest should be present
+        expect(recentTests.has(testIds[MAX_SAVED_TESTS_RECENT + 1]), "newest should be present").to.equal(true);
+      } catch (error) {
+        log("should only keep the most recent MAX_SAVED_TESTS_RECENT items error", LogLevel.ERROR, error);
+        throw error;
+      }
+    });
+
+    it("should return gracefully if loadHistoricalFromS3 throws", async () => {
+      try {
+        await TestSchedulerIntegration.populateCacheFromHistoricalWithLoadError(7);
+        // Should not throw, recent tests should be empty
+        expect(getRecentTests().size, "recentTests.size").to.equal(0);
+      } catch (error) {
+        log("should return gracefully if loadHistoricalFromS3 throws error", LogLevel.ERROR, error);
         throw error;
       }
     });

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "node": ">=20.0.0 <25.0.0"
   },
   "overrides": {
-    "eslint": "^10.0.0",
+    "eslint": "$eslint",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },


### PR DESCRIPTION
[Add recent test cache pre-population from historical data](https://github.com/FamilySearch/pewpew/commit/fffecbb0746e7a6b62a6aea5ad83a6f47a56de38) 

- Add TestManager.addRecentTests() to bulk-insert StoredTestData entries
  into the recent tests cache, evicting oldest entries when exceeding
  MAX_SAVED_TESTS_RECENT
- Add TestScheduler.populateCacheFromHistorical() to seed the recent
  tests cache on startup from S3 historical calendar data; filters to
  only the most recent N tests within the configured day window
- For historical entries with unknown color (non-red/green), attempt to
  load actual status from S3 via PpaasTestStatus.getStatus() using the
  same getUpdatedTestDataFromStoredData pattern as TestManager
- Only add Finished or Failed tests to the recent cache; skip Created,
  Running, Unknown, and other non-terminal statuses
- Insert oldest entries first so Map-based eviction (removeOldest)
  removes the oldest tests rather than the newest
- Add unit tests for both new functions covering edge cases: day cutoff
  filtering, status mapping, S3 status resolution, MAX limit enforcement,
  and error handling

[Fix for renovate dependencies of eslint](https://github.com/FamilySearch/pewpew/commit/0d65abcf25279db677be60fd7e72fc1a2cf7aff8)