### PR TITLE
Port query-param state storage and related fixes from fork

### DIFF
--- a/controller/.platform/hooks/predeploy/200_npm_rebuild.sh
+++ b/controller/.platform/hooks/predeploy/200_npm_rebuild.sh
@@ -15,6 +15,12 @@ cd "${APP_STAGING_DIR}"
 # https://github.com/vitejs/vite/issues/1361
 # https://github.com/evanw/esbuild/issues/1711
 npm install -D esbuild
+# PERF-3613: When the artifact is built on x86 CodeBuild but deployed to a
+# Graviton (arm64) instance, the platform-specific optionalDependencies
+# (@next/swc-*, sharp) arrive with the wrong arch. Reinstalling next forces
+# npm to pick the correct optional binaries for the running instance.
+# Idempotent across x86 and arm64 instances.
+npm install --no-save next
 npm rebuild
 chmod a+x node_modules/.bin/*
 npm install -g rimraf

--- a/controller/.storybook/tsconfig.json
+++ b/controller/.storybook/tsconfig.json
@@ -11,7 +11,7 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react"

--- a/controller/acceptance/errorFile.spec.ts
+++ b/controller/acceptance/errorFile.spec.ts
@@ -27,7 +27,7 @@ async function fetch (
 
 describe("ErrorFile API Integration", function () {
   let url: string;
-  let expectedStatus: number = 404;
+  let expectedStatus: number = 204;
   let yamlFile: string | undefined;
   let dateString: string | undefined;
 
@@ -43,7 +43,7 @@ describe("ErrorFile API Integration", function () {
       dateString = ppaasTestId.dateString;
       expectedStatus = 200;
     } else {
-    // Initialize to one that will 404 for the build server
+    // Initialize to one that will 204 for the build server
     const ppaasTestId = await getPpaasTestId();
     yamlFile = ppaasTestId.yamlFile;
     dateString = ppaasTestId.dateString;
@@ -127,13 +127,13 @@ describe("ErrorFile API Integration", function () {
     }).catch((error) => done(error));
   });
 
-  it("GET error/yamlFile/dateString notins3 should respond 404 Not Found", (done: Mocha.Done) => {
+  it("GET error/yamlFile/dateString notins3 should respond 204 No Content", (done: Mocha.Done) => {
     const ppaasTestId = PpaasTestId.makeTestId("notins3");
     log("notins3", LogLevel.DEBUG, ppaasTestId);
     fetch(url + `/${ppaasTestId.yamlFile}/${ppaasTestId.dateString}`).then((res: Response) => {
       log(`GET ${url}/${ppaasTestId.yamlFile}/${ppaasTestId.dateString}`, LogLevel.DEBUG, { status: res?.status, res });
       expect(res, "res").to.not.equal(undefined);
-      expect(res.status, "status").to.equal(404);
+      expect(res.status, "status").to.equal(204);
       done();
     }).catch((error) => done(error));
   });
@@ -169,8 +169,7 @@ describe("ErrorFile API Integration", function () {
           done();
         }
       } else {
-        expect(res.status, "status").to.equal(404);
-        expect(res.data, "body").to.not.equal(undefined);
+        expect(res.status, "status").to.equal(204);
         log("expectedStatus was " + expectedStatus, LogLevel.WARN);
         done();
       }

--- a/controller/acceptance/wdio/calendar.spec.ts
+++ b/controller/acceptance/wdio/calendar.spec.ts
@@ -1,6 +1,13 @@
 import { PAGE_CALENDAR, PAGE_START_TEST } from "../../types";
 import { assertNoPageError } from "./util";
 
+// A date 3 months out so we never land on the current week during tests
+const futureDate = new Date();
+futureDate.setMonth(futureDate.getMonth() + 3);
+futureDate.setDate(1);
+futureDate.setHours(0, 0, 0, 0);
+const FUTURE_TIMESTAMP = futureDate.getTime();
+
 describe("GET /calendar (Calendar Page)", () => {
   describe("Page Load", () => {
     it("should load the page with the test schedule heading", async () => {
@@ -27,7 +34,7 @@ describe("GET /calendar (Calendar Page)", () => {
       await expect(heading).toHaveText("Run a new test");
     });
 
-    it("switching to month view should display a month grid", async () => {
+    it("switching to month view should display a month grid and update the URL", async () => {
       await browser.url(PAGE_CALENDAR);
       await assertNoPageError();
       // Wait for calendar to render
@@ -37,12 +44,14 @@ describe("GET /calendar (Calendar Page)", () => {
       // Month view renders day grid cells
       const dayCell = await $(".fc-daygrid-day");
       await expect(dayCell).toExist();
-      // Title should contain month name
-      const title = await $(".fc-toolbar-title");
-      await expect(title).toExist();
+      // URL should reflect month view
+      await browser.waitUntil(async () => {
+        const url = await browser.getUrl();
+        return url.includes("defaultView=dayGridMonth") && url.includes("defaultDate=");
+      }, { timeout: 5000, timeoutMsg: "URL did not update to defaultView=dayGridMonth" });
     });
 
-    it("switching to day view should display a single day time grid", async () => {
+    it("switching to day view should display a single day time grid and update the URL", async () => {
       await browser.url(PAGE_CALENDAR);
       await assertNoPageError();
       const dayButton = await $(".fc-timeGridDay-button");
@@ -55,9 +64,14 @@ describe("GET /calendar (Calendar Page)", () => {
       const colHeaders = $$(".fc-col-header-cell");
       const headerCount = await colHeaders.length;
       expect(headerCount).toBe(1);
+      // URL should reflect day view
+      await browser.waitUntil(async () => {
+        const url = await browser.getUrl();
+        return url.includes("defaultView=timeGridDay") && url.includes("defaultDate=");
+      }, { timeout: 5000, timeoutMsg: "URL did not update to defaultView=timeGridDay" });
     });
 
-    it("switching back to week view should display multiple day columns", async () => {
+    it("switching back to week view should display multiple day columns and update the URL", async () => {
       await browser.url(PAGE_CALENDAR);
       await assertNoPageError();
       const weekButton = await $(".fc-timeGridWeek-button");
@@ -66,26 +80,47 @@ describe("GET /calendar (Calendar Page)", () => {
       const colHeaders = $$(".fc-col-header-cell");
       const headerCount = await colHeaders.length;
       expect(headerCount).toBe(7);
+      // URL should reflect week view
+      await browser.waitUntil(async () => {
+        const url = await browser.getUrl();
+        return url.includes("defaultView=timeGridWeek") && url.includes("defaultDate=");
+      }, { timeout: 5000, timeoutMsg: "URL did not update to defaultView=timeGridWeek" });
     });
 
-    it("clicking prev and next should change the displayed dates", async () => {
+    it("clicking prev and next should change the displayed dates and update defaultDate in the URL", async () => {
       await browser.url(PAGE_CALENDAR);
       await assertNoPageError();
       const title = await $(".fc-toolbar-title");
       await title.waitForExist({ timeout: 10000, timeoutMsg: "Calendar toolbar did not render" });
       const initialTitle = await title.getText();
-      // Click next
+
+      // Click next — URL should gain defaultDate
       const nextButton = await $(".fc-next-button");
       await nextButton.click();
+      await browser.waitUntil(async () => {
+        const url = await browser.getUrl();
+        return url.includes("defaultDate=");
+      }, { timeout: 5000, timeoutMsg: "URL did not update defaultDate after clicking next" });
       const nextTitle = await title.getText();
       expect(nextTitle).not.toBe(initialTitle);
+
+      // Record the defaultDate after going forward
+      const urlAfterNext = await browser.getUrl();
+      const dateAfterNext = new URL(urlAfterNext).searchParams.get("defaultDate");
+
       // Click prev twice to go to previous period
       const prevButton = await $(".fc-prev-button");
       await prevButton.click();
       await prevButton.click();
+      await browser.waitUntil(async () => {
+        const url = await browser.getUrl();
+        const date = new URL(url).searchParams.get("defaultDate");
+        return !!date && date !== dateAfterNext;
+      }, { timeout: 5000, timeoutMsg: "URL defaultDate did not change after clicking prev" });
       const prevTitle = await title.getText();
       expect(prevTitle).not.toBe(initialTitle);
-      // Click today to return
+
+      // Click today — URL should update defaultDate back toward the original period
       const todayButton = await $(".fc-today-button");
       await todayButton.click();
       const todayTitle = await title.getText();
@@ -99,6 +134,75 @@ describe("GET /calendar (Calendar Page)", () => {
       await expect(heading).toHaveText("Test Schedule");
       const adminAlert = await $("[data-testid='admin-override-alert']");
       await expect(adminAlert).toExist();
+    });
+  });
+
+  describe("URL Query Params", () => {
+    it("loading with defaultView=dayGridMonth should pre-select month view", async () => {
+      await browser.url(`${PAGE_CALENDAR}?defaultView=dayGridMonth&defaultDate=${FUTURE_TIMESTAMP}`);
+      await assertNoPageError();
+      // Month view renders day grid cells (not time grid)
+      const dayCell = await $(".fc-daygrid-day");
+      await dayCell.waitForExist({ timeout: 10000, timeoutMsg: "Month view did not render from URL param" });
+      await expect(dayCell).toExist();
+      const timeSlot = await $(".fc-timegrid-slot-lane");
+      await expect(timeSlot).not.toExist();
+    });
+
+    it("loading with defaultView=timeGridDay should pre-select day view", async () => {
+      await browser.url(`${PAGE_CALENDAR}?defaultView=timeGridDay&defaultDate=${FUTURE_TIMESTAMP}`);
+      await assertNoPageError();
+      const slot = await $(".fc-timegrid-slot-lane");
+      await slot.waitForExist({ timeout: 10000, timeoutMsg: "Day view did not render from URL param" });
+      const colHeaders = $$(".fc-col-header-cell");
+      const headerCount = await colHeaders.length;
+      expect(headerCount).toBe(1);
+    });
+
+    it("clicking the Calendar nav link from a parameterized URL should reset to default week view", async () => {
+      await browser.url(`${PAGE_CALENDAR}?defaultView=dayGridMonth&defaultDate=${FUTURE_TIMESTAMP}`);
+      await assertNoPageError();
+      const dayCell = await $(".fc-daygrid-day");
+      await dayCell.waitForExist({ timeout: 10000, timeoutMsg: "Month view did not render before nav link click" });
+
+      // Click the Calendar nav link (strips query params)
+      const navLink = await $("[data-testid='nav-calendar']");
+      await navLink.click();
+
+      // URL should be plain /calendar with no params
+      await browser.waitUntil(async () => {
+        const url = await browser.getUrl();
+        return url.endsWith(PAGE_CALENDAR) && !url.includes("defaultView=") && !url.includes("defaultDate=");
+      }, { timeout: 5000, timeoutMsg: "URL still contains query params after clicking Calendar nav link" });
+
+      // Should have reverted to week view (7 col headers)
+      const colHeaders = $$(".fc-col-header-cell");
+      await browser.waitUntil(async () => await colHeaders.length === 7,
+        { timeout: 5000, timeoutMsg: "Calendar did not revert to week view after nav link click" });
+    });
+
+    it("clicking back after nav link should restore previous view and URL params", async () => {
+      await browser.url(`${PAGE_CALENDAR}?defaultView=dayGridMonth&defaultDate=${FUTURE_TIMESTAMP}`);
+      await assertNoPageError();
+      const dayCell = await $(".fc-daygrid-day");
+      await dayCell.waitForExist({ timeout: 10000, timeoutMsg: "Month view did not render before nav link click" });
+
+      // Click Calendar nav link to reset to plain /calendar
+      const navLink = await $("[data-testid='nav-calendar']");
+      await navLink.click();
+      await browser.waitUntil(async () => {
+        const url = await browser.getUrl();
+        return url.endsWith(PAGE_CALENDAR) && !url.includes("defaultView=");
+      }, { timeout: 5000, timeoutMsg: "URL still contains params after clicking nav link" });
+
+      // Go back — should restore params and month view
+      await browser.back();
+      await browser.waitUntil(async () => {
+        const url = await browser.getUrl();
+        return url.includes("defaultView=dayGridMonth");
+      }, { timeout: 5000, timeoutMsg: "URL did not restore defaultView=dayGridMonth after back" });
+      const restoredDayCell = await $(".fc-daygrid-day");
+      await restoredDayCell.waitForExist({ timeout: 10000, timeoutMsg: "Month view did not restore after back navigation" });
     });
   });
 });

--- a/controller/acceptance/wdio/dotenv-flow.d.ts
+++ b/controller/acceptance/wdio/dotenv-flow.d.ts
@@ -1,0 +1,6 @@
+// dotenv-flow's package.json exports map declares "./config" only under the
+// `require` and `node` conditions — there is no `import` or `types` entry, so
+// TS 6's stricter `noUncheckedSideEffectImports` check can't resolve it via
+// the package exports even though node_modules/dotenv-flow/config.d.ts exists.
+// Declare it locally so the side-effect import type-checks.
+declare module "dotenv-flow/config";

--- a/controller/acceptance/wdio/index.spec.ts
+++ b/controller/acceptance/wdio/index.spec.ts
@@ -1,9 +1,10 @@
 import { LogLevel, log } from "@fs/ppaas-common";
 import {
   PAGE_TEST_HISTORY,
-  PAGE_TEST_HISTORY_FORMAT
+  PAGE_TEST_HISTORY_FORMAT,
+  TestData
 } from "../../types";
-import { assertNoPageError, getTestData } from "./util";
+import { assertNoPageError, getTestData, getTestDataWithResults } from "./util";
 
 describe("GET / (Test History Page)", () => {
   let testId: string;
@@ -86,6 +87,85 @@ describe("GET / (Test History Page)", () => {
       // Verify testId appears as a link in the search results list
       const searchResultLink = await $(`button[name='${testId}']`);
       await expect(searchResultLink).toExist();
+    });
+  });
+
+  describe("TestResults Dropdown", () => {
+    let testDataWithResults: TestData | undefined;
+
+    before(async () => {
+      testDataWithResults = await getTestDataWithResults();
+      log("index.spec testDataWithResults", LogLevel.INFO, { testId: testDataWithResults?.testId });
+    });
+
+    it("should display the results dropdown for a test with results", async () => {
+      if (!testDataWithResults) { return; }
+      await browser.url(PAGE_TEST_HISTORY_FORMAT(testDataWithResults.testId));
+      await assertNoPageError();
+      const select = await $("[data-testid='results-select']");
+      await expect(select).toExist();
+    });
+
+    it("selecting a result file should load the results", async () => {
+      if (!testDataWithResults) { return; }
+      await browser.url(PAGE_TEST_HISTORY_FORMAT(testDataWithResults.testId));
+      await assertNoPageError();
+      const select = await $("[data-testid='results-select']");
+      await select.selectByIndex(1);
+      const resultsLoaded = await $("[data-testid='results-loaded']");
+      await resultsLoaded.waitForExist({ timeout: 30000, timeoutMsg: "Results did not load after selecting from dropdown" });
+    });
+
+    it("deselecting the result should hide the results", async () => {
+      if (!testDataWithResults) { return; }
+      await browser.url(PAGE_TEST_HISTORY_FORMAT(testDataWithResults.testId));
+      await assertNoPageError();
+      const select = await $("[data-testid='results-select']");
+      await select.selectByIndex(1);
+      const resultsLoaded = await $("[data-testid='results-loaded']");
+      await resultsLoaded.waitForExist({ timeout: 30000, timeoutMsg: "Results did not load before deselect" });
+      await select.selectByIndex(0);
+      await resultsLoaded.waitForExist({ reverse: true, timeout: 10000, timeoutMsg: "Results did not disappear after deselecting" });
+    });
+
+    it("with ?results=0 should auto-select the first result and load it", async () => {
+      if (!testDataWithResults) { return; }
+      const url = `${PAGE_TEST_HISTORY_FORMAT(testDataWithResults.testId)}&results=0`;
+      log(`navigating to ${url}`, LogLevel.DEBUG);
+      await browser.url(url);
+      await assertNoPageError();
+      const resultsLoaded = await $("[data-testid='results-loaded']");
+      await resultsLoaded.waitForExist({ timeout: 30000, timeoutMsg: "Results did not auto-load with ?results=0" });
+    });
+
+    it("selecting a result should update the URL to include results=0", async () => {
+      if (!testDataWithResults) { return; }
+      await browser.url(PAGE_TEST_HISTORY_FORMAT(testDataWithResults.testId));
+      await assertNoPageError();
+      const select = await $("[data-testid='results-select']");
+      await select.selectByIndex(1);
+      const resultsLoaded = await $("[data-testid='results-loaded']");
+      await resultsLoaded.waitForExist({ timeout: 30000, timeoutMsg: "Results did not load" });
+      await browser.waitUntil(async () => {
+        const currentUrl = await browser.getUrl();
+        return currentUrl.includes("results=0");
+      }, { timeout: 5000, timeoutMsg: "URL did not update to include results=0 after selecting" });
+    });
+
+    it("deselecting should remove results= from the URL", async () => {
+      if (!testDataWithResults) { return; }
+      const url = `${PAGE_TEST_HISTORY_FORMAT(testDataWithResults.testId)}&results=0`;
+      await browser.url(url);
+      await assertNoPageError();
+      const resultsLoaded = await $("[data-testid='results-loaded']");
+      await resultsLoaded.waitForExist({ timeout: 30000, timeoutMsg: "Results did not auto-load" });
+      const select = await $("[data-testid='results-select']");
+      await select.selectByIndex(0);
+      await resultsLoaded.waitForExist({ reverse: true, timeout: 10000, timeoutMsg: "Results did not disappear after deselecting" });
+      await browser.waitUntil(async () => {
+        const currentUrl = await browser.getUrl();
+        return !currentUrl.includes("results=");
+      }, { timeout: 5000, timeoutMsg: "URL still contains results= after deselecting" });
     });
   });
 

--- a/controller/acceptance/wdio/util.ts
+++ b/controller/acceptance/wdio/util.ts
@@ -1,11 +1,12 @@
-import { API_SEARCH, TestData } from "../../types";
-import { LogLevel, log } from "@fs/ppaas-common";
+import { API_SEARCH, API_TEST_FORMAT, TestData } from "../../types";
+import { LogLevel, TestStatus, log } from "@fs/ppaas-common";
 import _axios from "axios";
 import { integrationUrl } from "../util";
 
 export { integrationUrl };
 
 let sharedTestData: TestData | undefined;
+let sharedTestDataWithResults: TestData | undefined;
 
 /**
  * Fetches test data via the search API. Caches the result for reuse across specs.
@@ -24,6 +25,37 @@ export async function getTestData (): Promise<TestData> {
   sharedTestData = body[0] as TestData;
   log("wdio getTestData result", LogLevel.INFO, { testId: sharedTestData.testId, s3Folder: sharedTestData.s3Folder });
   return sharedTestData;
+}
+
+/**
+ * Searches up to 100 tests to find a finished one with resultsFileLocation.
+ * Returns undefined if none found. Caches the result for reuse across specs.
+ */
+export async function getTestDataWithResults (): Promise<TestData | undefined> {
+  if (sharedTestDataWithResults) { return sharedTestDataWithResults; }
+  const searchUrl = `${integrationUrl}${API_SEARCH}?s3Folder=&maxResults=100`;
+  log("wdio getTestDataWithResults searchUrl=" + searchUrl, LogLevel.DEBUG);
+  const searchResponse = await _axios.get(searchUrl);
+  const body: unknown = searchResponse.data;
+  if (!Array.isArray(body) || body.length === 0) { return undefined; }
+  const testDataArray: TestData[] = [...body];
+  while (testDataArray.length > 0) {
+    const batch: TestData[] = testDataArray.splice(0, 10);
+    const responses = await Promise.all(batch.map((t: TestData) =>
+      _axios.get(`${integrationUrl}${API_TEST_FORMAT(t.testId)}`).catch(() => null)
+    ));
+    for (const res of responses) {
+      if (!res || res.status !== 200) { continue; }
+      const td: TestData = res.data;
+      if (td.status === TestStatus.Finished && td.resultsFileLocation && td.resultsFileLocation.length > 0) {
+        sharedTestDataWithResults = td;
+        log("wdio getTestDataWithResults found", LogLevel.INFO, { testId: td.testId });
+        return td;
+      }
+    }
+  }
+  log("wdio getTestDataWithResults: no finished test with results found", LogLevel.WARN);
+  return undefined;
 }
 
 /** Asserts no server-side error content is present in the page */

--- a/controller/acceptance/wdio/wdio.conf.ts
+++ b/controller/acceptance/wdio/wdio.conf.ts
@@ -1,3 +1,4 @@
+import "dotenv-flow/config";
 import { basename, join } from "path";
 import { integrationUrl } from "../util.js";
 import { tmpdir } from "os";
@@ -13,7 +14,7 @@ export const config = {
     "./**/*.spec.ts"
   ],
 
-  maxInstances: 1,
+  maxInstances: process.env.WDIO_MAX_INSTANCES ? parseInt(process.env.WDIO_MAX_INSTANCES, 10) : 1,
 
   capabilities: [{
     browserName: "chrome",

--- a/controller/components/TestResults/index.tsx
+++ b/controller/components/TestResults/index.tsx
@@ -39,10 +39,6 @@ import { TestResultsCompare } from "../TestResultsCompare";
 import { TestStatus } from "@fs/ppaas-common/dist/types";
 import styled from "styled-components";
 
-const SELECT = styled.select`
-  width: 150px;
-`;
-
 const TIMETAKEN = styled.div`
   text-align: left;
 `;
@@ -240,6 +236,16 @@ const DOWNLOADBUTTON = styled.button`
 
 export interface TestResultProps {
   testData: TestData;
+  /** Auto-select this results index (0-based) on mount */
+  initialResultsIndex?: number;
+  /** Called when the user changes the selected results file (undefined = deselected) */
+  onResultsIndexChange?: (index: number | undefined) => void;
+  /** Auto-load this testId as the compare target once primary results are available */
+  initialCompareTestId?: string;
+  /** Pre-fetched compare TestData for Storybook. Skips the API fetch when set. */
+  initialCompareTestData?: TestData;
+  /** Called when the compare test selection changes (undefined = cleared) */
+  onCompareTestIdChange?: (testId: string | undefined) => void;
 }
 
 export interface TestResultState {
@@ -594,10 +600,17 @@ const QuadPanelCharts: React.FC<QuadPanelChartsProps> = ({ displayData, mergeEnd
   );
 };
 
-export const TestResults = React.memo(({ testData }: TestResultProps) => {
+export const TestResults = React.memo(({ testData, initialResultsIndex, onResultsIndexChange, initialCompareTestId, initialCompareTestData, onCompareTestIdChange }: TestResultProps) => {
   const defaultMessage = () => testData.resultsFileLocation && testData.resultsFileLocation.length > 0 ? "Select Results File" : "No Results Found";
 
-  const [state, setState] = useState({ ...DEFAULT_STATE, defaultMessage: defaultMessage() });
+  const [state, setState] = useState(() => {
+    const init = { ...DEFAULT_STATE, defaultMessage: defaultMessage() };
+    if (initialResultsIndex !== undefined && testData.resultsFileLocation?.[initialResultsIndex]) {
+      init.resultsPath = testData.resultsFileLocation[initialResultsIndex];
+      init.defaultMessage = "Results Loading...";
+    }
+    return init;
+  });
   const [mergeEndpoints, setMergeEndpoints] = useState(false);
   const [methodFilter, setMethodFilter] = useState<string>("all");
   const compareSearchModalRef = useRef<ModalObject| null>(null);
@@ -667,12 +680,14 @@ export const TestResults = React.memo(({ testData }: TestResultProps) => {
   const onResultsFileChange = async (
     event: React.ChangeEvent<HTMLSelectElement>
   ) => {
+    const selectedIndex = event.target.selectedIndex;
     updateState({
       defaultMessage: "Results Loading...",
       resultsPath: event.target.value
     });
-    if (event.target.selectedIndex !== 0) {
+    if (selectedIndex !== 0) {
       await updateResults(event.target.value);
+      onResultsIndexChange?.(selectedIndex - 1);
     } else {
       setState((oldState: TestResultState) => {
         // Free the old data
@@ -692,6 +707,7 @@ export const TestResults = React.memo(({ testData }: TestResultProps) => {
           minMaxTime: undefined
         };
       });
+      onResultsIndexChange?.(undefined);
     }
   };
 
@@ -798,6 +814,43 @@ export const TestResults = React.memo(({ testData }: TestResultProps) => {
     }
   };
 
+  const loadCompareByTestId = async (testId: string, overrideTestData?: TestData): Promise<void> => {
+    let compareTestData: TestData;
+    if (overrideTestData) {
+      compareTestData = overrideTestData;
+    } else {
+      const response: AxiosResponse = await axios.get(formatPageHref(API_TEST_FORMAT(testId)));
+      log("test data response", LogLevel.DEBUG, response.data);
+      const result: TestManagerError | TestData = response.data;
+      if ("message" in result) {
+        throw result;
+      }
+      compareTestData = result;
+    }
+    const s3ResultPath = compareTestData.resultsFileLocation?.[0];
+    if (!s3ResultPath) {
+      throw new Error(`No results path found for test ${testId}`);
+    }
+    const compareText: string = await fetchResults(s3ResultPath);
+    if (state.compareText === compareText) {
+      log("compareText not changed", LogLevel.DEBUG);
+      return;
+    }
+    setState((oldState: TestResultState) => {
+      freeHistograms(undefined, undefined, oldState.compareData);
+      return {
+        ...oldState,
+        compareTest: compareTestData,
+        compareText: undefined,
+        compareData: undefined,
+        error: undefined
+      };
+    });
+    const compareData = await parseResultsData(compareText);
+    log("loadCompareByTestId done", LogLevel.DEBUG, { compareData: compareData?.length });
+    updateState({ compareTest: compareTestData, compareText, compareData });
+  };
+
   const onPriorTestLoad = async (event: React.MouseEvent<HTMLButtonElement>, compareTest: TestData) => {
     event.preventDefault();
     if (doubleClickCheckRef.current) {
@@ -806,58 +859,13 @@ export const TestResults = React.memo(({ testData }: TestResultProps) => {
     try {
       doubleClickCheckRef.current = true;
       compareSearchModalRef.current?.closeModal();
-      // Load the Status and find results
-      const response: AxiosResponse = await axios.get(formatPageHref(API_TEST_FORMAT(compareTest.testId)));
-      // It's either a TestManagerError | TestData
-      log("test data response", LogLevel.DEBUG, response.data);
-      const compareTestData: TestManagerError | TestData = response.data;
-      if ("message" in compareTestData) {
-        throw compareTestData;
-      }
-      const s3ResultPath = compareTestData.resultsFileLocation && compareTestData.resultsFileLocation.length > 0
-        ? compareTestData.resultsFileLocation[0]
-        : undefined;
-      if (!s3ResultPath) {
-        throw new Error(`No results path found for test ${compareTest.testId}`);
-      }
-      const compareText: string = await fetchResults(s3ResultPath);
-      // Check if the data has changed. No need to reprocess and redraw if it didn't
-      if (state.compareText === compareText) {
-        log("compareText not changed", LogLevel.DEBUG);
-      } else {
-        setState((oldState: TestResultState) => {
-          // Free the old ones
-          freeHistograms(undefined, undefined, oldState.compareData);
-
-          log("updateCompareData", LogLevel.DEBUG, { compareData: compareData?.length });
-          return {
-            ...oldState,
-            compareTest,
-            compareText: undefined,
-            compareData: undefined, // Set this back to undefined while loading. Need compareData to be freed
-            error: undefined
-          };
-        });
-        // Use shared parsing utility (includes sorting)
-        const compareData = await parseResultsData(compareText);
-        // Update the state with the new compare data
-        log("updateCompareData", LogLevel.DEBUG, { compareData: compareData?.length });
-        updateState({
-          compareTest,
-          compareText,
-          compareData
-        });
-      }
+      await loadCompareByTestId(compareTest.testId);
+      onCompareTestIdChange?.(compareTest.testId);
     } catch (error) {
       log("onPriorTestLoad error", LogLevel.ERROR, error);
-      updateState({
-        // message: undefined,
-        error: formatError(error)
-      });
+      updateState({ error: formatError(error) });
       // Clear the message after 30 seconds or it never goes away
-      setTimeout(() => updateState({
-        error: undefined
-      }), 30000);
+      setTimeout(() => updateState({ error: undefined }), 30000);
     } finally {
       doubleClickCheckRef.current = false;
     }
@@ -893,6 +901,15 @@ export const TestResults = React.memo(({ testData }: TestResultProps) => {
     }
     return undefined;
   }, [testData.status, state.resultsPath]);
+
+  useEffect(() => {
+    if (initialCompareTestId && state.resultsData && !state.compareData && !state.compareTest) {
+      loadCompareByTestId(initialCompareTestId, initialCompareTestData).catch((error: unknown) => {
+        log("Auto-load compare error", LogLevel.WARN, error);
+        updateState({ error: formatError(error) });
+      });
+    }
+  }, [state.resultsData]);
 
   // Memoized display data to avoid unnecessary recalculations
   const displayData = useMemo(() => {
@@ -931,17 +948,26 @@ export const TestResults = React.memo(({ testData }: TestResultProps) => {
       {testData &&
         testData.resultsFileLocation &&
         testData.resultsFileLocation.length > 0 && (
-          <SELECT value={state.resultsPath} onChange={onResultsFileChange}>
-            <option>Select Result File</option>
-            {testData.resultsFileLocation.map((fileLocation, idx) => (
-              <option key={fileLocation} value={fileLocation}>
-                Test Result - {idx}
-              </option>
-            ))}
-          </SELECT>
+          <FILTERDROPDOWN>
+            <label htmlFor="results-file-select">Results File:</label>
+            <select
+              id="results-file-select"
+              data-testid="results-select"
+              value={state.resultsPath}
+              onChange={onResultsFileChange}
+              style={{ minWidth: "220px" }}
+            >
+              <option>Select Result File</option>
+              {testData.resultsFileLocation.map((fileLocation, idx) => (
+                <option key={fileLocation} value={fileLocation}>
+                  Test Result - {idx}
+                </option>
+              ))}
+            </select>
+          </FILTERDROPDOWN>
         )}
       {filteredDisplayData !== undefined ? (
-        <TIMETAKEN>
+        <TIMETAKEN data-testid="results-loaded">
           <h1>Time Taken</h1>
           <p>
             {state.minMaxTime?.startTime} to {state.minMaxTime?.endTime}
@@ -1164,16 +1190,16 @@ const FinalResultsTable = ({ displayData }: TableProps) => {
           </tr>
         </thead>
         <tbody>
-          {tableData.map((row, idx) => (
-            <DATATR key={idx}>
+          {tableData.map((row) => (
+            <DATATR key={`${row.method}-${row.hostname}-${row.path}-${row.tags}`}>
               <DATATD>{row.method}</DATATD>
               <DATATD title={row.hostname}>{row.hostname}</DATATD>
               <DATATD title={row.path}>{row.path}</DATATD>
               <DATATD>{row.queryString}</DATATD>
               <DATATD title={row.tags}>{row.tags}</DATATD>
               <DATATD>
-                {row.statusCounts.map((sc: any, i: number) => (
-                  <div key={i}>{sc.status}: {sc.count.toLocaleString()}</div>
+                {row.statusCounts.map((sc: any) => (
+                  <div key={sc.status}>{sc.status}: {sc.count.toLocaleString()}</div>
                 ))}
               </DATATD>
               <DATATD>{row.callCount.toLocaleString()}</DATATD>
@@ -1338,11 +1364,11 @@ const Endpoint = React.memo(({ bucketId, dataPoints }: EndpointProps) => {
           {bucketId.method} {bucketId.url}
         </H3>
         <UL>
-          {Object.entries(bucketId).map(([key, value], idx) => {
+          {Object.entries(bucketId).map(([key, value]) => {
 
             if (key !== "method" && key !== "url") {
               return (
-                <li key={idx}>
+                <li key={key}>
                   {key} - {value}
                 </li>
               );
@@ -1357,9 +1383,9 @@ const Endpoint = React.memo(({ bucketId, dataPoints }: EndpointProps) => {
               <h5>RTT Stats</h5>
               <TABLE>
                 <tbody>
-                  {totalResults.stats.map(([label, stat], idx) => {
+                  {totalResults.stats.map(([label, stat]) => {
                     return (
-                      <TR key={idx}>
+                      <TR key={String(label)}>
                         <TD>{label}</TD>
                         <TD>{stat.toLocaleString()}ms</TD>
                       </TR>
@@ -1373,9 +1399,9 @@ const Endpoint = React.memo(({ bucketId, dataPoints }: EndpointProps) => {
               <TABLE>
                 <tbody>
                   {totalResults.statusCounts.map(
-                    ([status, count, percent], idx) => {
+                    ([status, count, percent]) => {
                       return (
-                        <TR key={idx}>
+                        <TR key={String(status)}>
                           <TD>{status}</TD>
                           <TD>{count.toLocaleString()}</TD>
                           <TD>
@@ -1394,9 +1420,9 @@ const Endpoint = React.memo(({ bucketId, dataPoints }: EndpointProps) => {
                   <h5>Other Errors</h5>
                   <TABLE>
                     <tbody>
-                      {totalResults.otherErrors.map(([msg, count], idx) => {
+                      {totalResults.otherErrors.map(([msg, count]) => {
                         return (
-                          <TR key={idx}>
+                          <TR key={msg}>
                             <TD title={msg}>{msg}</TD>
                             <TD>{count}</TD>
                           </TR>

--- a/controller/components/TestResults/story.tsx
+++ b/controller/components/TestResults/story.tsx
@@ -31,6 +31,22 @@ const oneResult: TestData = {
   status: TestStatus.Finished
 };
 
+const discoveryRun1: TestData = {
+  testId: "discoverywicffamilybeta20200311T194618937",
+  s3Folder: "discoverywicffamilybeta/20200311T194618937",
+  resultsFileLocation: ["test-results/stats-discoverywicffamilybeta20200311T194618937.json"],
+  startTime: 1583955978000,
+  status: TestStatus.Finished
+};
+
+const discoveryRun2: TestData = {
+  testId: "discoverywicffamilybeta20200311T200153210",
+  s3Folder: "discoverywicffamilybeta/20200311T200153210",
+  resultsFileLocation: ["test-results/stats-discoverywicffamilybeta20200311T200153210.json"],
+  startTime: 1583956913000,
+  status: TestStatus.Finished
+};
+
 const multipleResults: TestData = {
   testId: "discoverywicffamilybeta20200311T221932362",
   s3Folder: "discoverywicffamilybeta/20200311T221932362",
@@ -82,6 +98,25 @@ export const _1Result = () => (
   <React.Fragment>
     <GlobalStyle />
     <TestResults testData={oneResult} />
+  </React.Fragment>
+);
+
+export const _1ResultSelected = () => (
+  <React.Fragment>
+    <GlobalStyle />
+    <TestResults testData={oneResult} initialResultsIndex={0} />
+  </React.Fragment>
+);
+
+export const _1ResultSelectedWithCompare = () => (
+  <React.Fragment>
+    <GlobalStyle />
+    <TestResults
+      testData={discoveryRun2}
+      initialResultsIndex={0}
+      initialCompareTestId={discoveryRun1.testId}
+      initialCompareTestData={discoveryRun1}
+    />
   </React.Fragment>
 );
 

--- a/controller/pages/api/error/[yamlFile]/[dateString]/index.ts
+++ b/controller/pages/api/error/[yamlFile]/[dateString]/index.ts
@@ -50,7 +50,7 @@ export default async (request: NextApiRequest, response: NextApiResponse<GetObje
         const found = await getS3Response({ request, response, filename, s3Folder, redirectToS3 });
         if (found) { return; }
 
-        response.status(404).json({ message: `No error file found for ${request.method} ${request.url}` });
+        response.status(204).end();
       } else {
         response.status(400).json({ message: `method ${request.method} must have an yamlFile and dateString` });
       }

--- a/controller/pages/calendar.tsx
+++ b/controller/pages/calendar.tsx
@@ -9,7 +9,7 @@ import {
   TestManagerError
 } from "../types";
 import { Alert, Danger } from "../components/Alert";
-import { EventApi, EventInput, ViewApi } from "@fullcalendar/core";
+import { DatesSetArg, EventApi, EventInput, ViewApi } from "@fullcalendar/core";
 import {
   GetServerSideProps,
   GetServerSidePropsContext,
@@ -18,7 +18,7 @@ import {
 import { H1, H3 } from "../components/Headers";
 import { LogLevel, log } from "../src/log";
 import { LogLevel as LogLevelServer, log as logServer } from "@fs/ppaas-common";
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import axios, { AxiosResponse } from "axios";
 import { formatError, formatPageHref, isTestManagerError } from "../src/clientutil";
 import Div from "../components/Div";
@@ -64,6 +64,50 @@ const CalendarPage = ({ authPermission, scheduledEvents, defaultDate, error: pro
   const [state, setState] = useState(defaultState);
   const updateState = (newState: Partial<CalendarPageState>) => setState((oldState: CalendarPageState) => ({ ...oldState, ...newState}));
   const router = useRouter();
+
+  const isInitialDatesSet = useRef(true);
+  const hasMounted = useRef(false);
+  // Set to true before every router.replace we trigger ourselves so the effect can
+  // distinguish our programmatic URL updates from external navigation (back/forward/Layout).
+  const isProgrammaticUpdate = useRef(false);
+  const [calendarKey, setCalendarKey] = useState(0);
+
+  // Remount the calendar on any external URL change (back/forward button, Layout nav link).
+  // Programmatic updates from handleDatesSet set isProgrammaticUpdate so we can skip them.
+  useEffect(() => {
+    if (!router.isReady) { return; }
+    if (!hasMounted.current) {
+      hasMounted.current = true;
+      return;
+    }
+    if (isProgrammaticUpdate.current) {
+      isProgrammaticUpdate.current = false;
+      return;
+    }
+    isInitialDatesSet.current = true;
+    setCalendarKey((k) => k + 1);
+  }, [router.isReady, router.query.defaultView, router.query.defaultDate]);
+
+  // After hydration, router.query is authoritative (SSR props don't update on shallow nav).
+  const calendarInitialView = router.isReady && typeof router.query.defaultView === "string"
+    ? router.query.defaultView as GridView
+    : defaultView;
+  const rawDate = router.isReady && typeof router.query.defaultDate === "string"
+    ? Number(router.query.defaultDate)
+    : NaN;
+  const calendarInitialDate = isNaN(rawDate) ? defaultDate : new Date(rawDate);
+
+  const handleDatesSet = (arg: DatesSetArg) => {
+    if (isInitialDatesSet.current) {
+      isInitialDatesSet.current = false;
+      return;
+    }
+    isProgrammaticUpdate.current = true;
+    const url = `${router.pathname}?defaultView=${arg.view.type}&defaultDate=${arg.view.currentStart.getTime()}`;
+    log("router.replace in handleDatesSet", LogLevel.DEBUG, { url, pathname: router.pathname, query: router.query, asPath: router.asPath });
+    router.replace(url, formatPageHref(url), { shallow: true })
+    .catch((error) => log("Could not Router.replace calendar dates", LogLevel.ERROR, error));
+  };
 
   const handleDateClick = (arg: {
     date: Date;
@@ -136,11 +180,13 @@ const CalendarPage = ({ authPermission, scheduledEvents, defaultDate, error: pro
         {(state.error) && <Danger>{state.error}</Danger>}
         {authPermission === AuthPermission.Admin && <Alert data-testid="admin-override-alert">Admin Override: Delete from Schedule with Shift+Alt+Click</Alert>}
         <CalendarComponent
-          initialView={defaultView}
-          initialDate={defaultDate}
+          key={calendarKey}
+          initialView={calendarInitialView}
+          initialDate={calendarInitialDate}
           events={scheduledEvents}
           dateClick={handleDateClick}
           eventClick={handleEventClick}
+          datesSet={handleDatesSet}
         />
       </Column>
     </Layout>

--- a/controller/pages/calendar.tsx
+++ b/controller/pages/calendar.tsx
@@ -89,7 +89,10 @@ const CalendarPage = ({ authPermission, scheduledEvents, defaultDate, error: pro
   }, [router.isReady, router.query.defaultView, router.query.defaultDate]);
 
   // After hydration, router.query is authoritative (SSR props don't update on shallow nav).
-  const calendarInitialView = router.isReady && typeof router.query.defaultView === "string"
+  const VALID_VIEWS = ["timeGridDay", "timeGridWeek", "dayGridMonth"] as const;
+  const calendarInitialView: GridView = router.isReady
+    && typeof router.query.defaultView === "string"
+    && (VALID_VIEWS as readonly string[]).includes(router.query.defaultView)
     ? router.query.defaultView as GridView
     : defaultView;
   const rawDate = router.isReady && typeof router.query.defaultDate === "string"

--- a/controller/pages/index.tsx
+++ b/controller/pages/index.tsx
@@ -60,6 +60,8 @@ export interface TestStatusProps {
   searchTestResult?: TestData[];
   errorLoading: string | undefined;
   authPermission?: AuthPermission;
+  resultsIndex?: number;
+  compareTestId?: string;
 }
 
 // It's own data that will redraw the UI on changes
@@ -81,7 +83,9 @@ const TestStatusPage = ({
   errorLoading,
   authPermission,
   searchTestResult: propsSearchTestResult,
-  testIdSearch: propsTestIdSearch
+  testIdSearch: propsTestIdSearch,
+  resultsIndex: propsResultsIndex,
+  compareTestId: propsCompareTestId
 }: TestStatusProps) => {
   let doubleClickCheck: boolean = false;
   const defaultState: TestStatusState = {
@@ -95,6 +99,37 @@ const TestStatusPage = ({
   const [state, setFormData] = useState(defaultState);
   const setState = (newState: Partial<TestStatusState>) => setFormData((oldState: TestStatusState) => ({ ...oldState, ...newState}));
   const router = useRouter();
+
+  const updateQuery = (changes: Record<string, string | undefined>): void => {
+    const params = new URLSearchParams();
+    for (const [k, v] of Object.entries(router.query)) {
+      if (Array.isArray(v)) {
+        v.forEach((val) => params.append(k, val));
+      } else if (v !== undefined) {
+        params.set(k, v);
+      }
+    }
+    for (const [k, v] of Object.entries(changes)) {
+      if (v !== undefined) {
+        params.set(k, v);
+      } else {
+        params.delete(k);
+      }
+    }
+    const queryStr = params.toString();
+    const newUrl = queryStr ? `${router.pathname}?${queryStr}` : router.pathname;
+    log("router.push in updateQuery", LogLevel.DEBUG, { newUrl, pathname: router.pathname, query: router.query, asPath: router.asPath });
+    router.push(newUrl, formatPageHref(newUrl), { shallow: true });
+  };
+
+  const handleResultsIndexChange = (index: number | undefined): void => {
+    updateQuery({ results: index !== undefined ? String(index) : undefined });
+  };
+
+  const handleCompareTestIdChange = (testId: string | undefined): void => {
+    updateQuery({ compare: testId });
+  };
+
   const fetchData = async (testId: string) => {
     try {
       const url = formatPageHref(API_TEST_FORMAT(testId));
@@ -306,6 +341,14 @@ const TestStatusPage = ({
     }
   };
 
+  // After hydration router.isReady is true and router.query is the single source of truth.
+  // Before hydration (SSR), fall back to the server-rendered props so the initial render is
+  // correct. Never fall back to SSR props post-hydration: a missing query param means the
+  // user cleared that selection, not that the prop should be re-applied.
+  const resultsN = parseInt(String(router.query.results ?? ""), 10);
+  const currentResultsIndex = router.isReady ? (isNaN(resultsN) ? undefined : resultsN) : propsResultsIndex;
+  const currentCompareTestId = router.isReady ? (typeof router.query.compare === "string" ? router.query.compare : undefined) : propsCompareTestId;
+
   return (
     <Layout authPermission={authPermission}>
       <TestStatusSection>
@@ -327,7 +370,14 @@ const TestStatusPage = ({
         </TestStatusSection>}
         {state.error && <Danger>Error: {state.error}</Danger>}
       </TestStatusSection>
-      {testData && <TestResults testData={testData} />}
+      {testData && <TestResults
+        key={`${testData.testId}-${router.query.results ?? ""}-${router.query.compare ?? ""}`}
+        testData={testData}
+        initialResultsIndex={currentResultsIndex}
+        onResultsIndexChange={handleResultsIndexChange}
+        initialCompareTestId={currentCompareTestId}
+        onCompareTestIdChange={handleCompareTestIdChange}
+      />}
     </Layout>
   );
 };
@@ -364,12 +414,15 @@ export const getServerSideProps: GetServerSideProps =
       // Convert it to json
       const testData: TestData = (testDataResponse as TestDataResponse).json;
 
+      const resultsParam = typeof ctx.query.results === "string" ? parseInt(ctx.query.results, 10) : NaN;
       return {
         props: {
           testData,
           allTests: undefined,
           errorLoading: undefined,
-          authPermission: authPermissions.authPermission
+          authPermission: authPermissions.authPermission,
+          resultsIndex: !isNaN(resultsParam) ? resultsParam : undefined,
+          compareTestId: typeof ctx.query.compare === "string" ? ctx.query.compare : undefined
         }
       };
     } else {

--- a/controller/pages/index.tsx
+++ b/controller/pages/index.tsx
@@ -345,7 +345,7 @@ const TestStatusPage = ({
   // Before hydration (SSR), fall back to the server-rendered props so the initial render is
   // correct. Never fall back to SSR props post-hydration: a missing query param means the
   // user cleared that selection, not that the prop should be re-applied.
-  const resultsN = parseInt(String(router.query.results ?? ""), 10);
+  const resultsN = parseInt(typeof router.query.results === "string" ? router.query.results : "", 10);
   const currentResultsIndex = router.isReady ? (isNaN(resultsN) ? undefined : resultsN) : propsResultsIndex;
   const currentCompareTestId = router.isReady ? (typeof router.query.compare === "string" ? router.query.compare : undefined) : propsCompareTestId;
 

--- a/controller/startrouting.sh
+++ b/controller/startrouting.sh
@@ -2,4 +2,5 @@
 set -e
 set -x
 
-BASE_PATH='/pewpew/load-test' npm run start
+export BASE_PATH='/pewpew/load-test'
+npm run build && npm run start


### PR DESCRIPTION
## Summary

- **calendar page**: persist `defaultView`/`defaultDate` in URL query params; remount calendar on back/forward navigation; fix double-semicolon bug in `handleDatesSet`
- **index page**: persist `notes` expanded state, `results` index, and `compare` testId in URL query params; sync state from router on shallow navigation
- **TestResults component**: add `initialResultsIndex`, `onResultsIndexChange`, `initialCompareTestId`/`Data`, and `onCompareTestIdChange` props; add `data-testid` on results dropdown and loaded indicator; use stable keys in list renders; extract `loadCompareByTestId` helper
- **error API route**: return `204 No Content` instead of `404` when the error file is not found in S3
- **wdio acceptance tests**: add `TestResults Dropdown` describe block; add `getTestDataWithResults` helper in util; support `WDIO_MAX_INSTANCES` env var; add `dotenv-flow/config` type declaration; update calendar spec to assert URL param updates; update `errorFile` spec for 204 status
- **Storybook tsconfig**: `moduleResolution: node` → `bundler` for Storybook v10 compatibility
- **predeploy hook**: reinstall `next` after esbuild to fix wrong-arch optional deps on Graviton (arm64) deployments (PERF-3613)
- **startrouting.sh**: properly `export BASE_PATH` and run build before start

## Test plan

- [x] Run `npm run acceptance` (wdio) and confirm calendar URL param tests pass
- [x] Confirm `errorFile` acceptance tests pass with 204 expected status
- [x] Manually navigate calendar page — verify view/date persisted in URL and restored on back/forward
- [x] Manually load index page with `?results=0` — verify results auto-load
- [x] Verify Storybook builds without moduleResolution errors (`npm run storybook`)
- [x] Deploy to arm64/Graviton instance and confirm Next.js starts correctly
