### PR TITLE
Merge master into 0.6.0-scripting-dev (PR #380)

### DIFF
--- a/agent/.github/workflows/pr.yml
+++ b/agent/.github/workflows/pr.yml
@@ -42,8 +42,10 @@ jobs:
     strategy:
       matrix:
         node-version: [22.x, 24.x]
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
+      fail-fast: false
     needs: changedfiles
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     env:
       DOWNLOAD_PEWPEW: true
 

--- a/common/.github/workflows/pr.yml
+++ b/common/.github/workflows/pr.yml
@@ -8,7 +8,8 @@ jobs:
     strategy:
       matrix:
         node-version: [22.x, 24.x]
-    runs-on: ubuntu-latest
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.runner }}
     # env:
     #   USE_XVFB: true
 

--- a/common/src/util/util.ts
+++ b/common/src/util/util.ts
@@ -15,14 +15,17 @@ export const PEWPEW_BINARY_EXECUTABLE_LINUX = "pewpew";
 export const PEWPEW_BINARY_EXECUTABLE_WINDOWS = "pewpew.exe";
 export const PEWPEW_BINARY_EXECUTABLE_MAC = "pewpew.mac";
 export const PEWPEW_BINARY_EXECUTABLE_ARM = "pewpew.arm";
-export const PEWPEW_BINARY_EXECUTABLE = process.env.PEWPEW_BINARY_EXECUTABLE
-  || (os.platform() === "win32"
-    ? PEWPEW_BINARY_EXECUTABLE_WINDOWS
-    : os.platform() === "darwin"
-      ? PEWPEW_BINARY_EXECUTABLE_MAC
-      : os.arch() === "arm64"
-        ? PEWPEW_BINARY_EXECUTABLE_ARM
-        : PEWPEW_BINARY_EXECUTABLE_LINUX);
+export const PEWPEW_BINARY_EXECUTABLE = process.env.PEWPEW_BINARY_EXECUTABLE || (() => {
+  if (os.platform() === "win32") {
+    return PEWPEW_BINARY_EXECUTABLE_WINDOWS;
+  } else if (os.platform() === "darwin") {
+    return PEWPEW_BINARY_EXECUTABLE_MAC;
+  } else if (os.arch() === "arm64") {
+    return PEWPEW_BINARY_EXECUTABLE_ARM;
+  } else {
+    return PEWPEW_BINARY_EXECUTABLE_LINUX;
+  }
+})();
 export const PEWPEW_BINARY_EXECUTABLE_NAMES = [
   PEWPEW_BINARY_EXECUTABLE_LINUX,
   PEWPEW_BINARY_EXECUTABLE_WINDOWS,

--- a/common/test/util.spec.ts
+++ b/common/test/util.spec.ts
@@ -1,9 +1,15 @@
 import { expect } from "chai";
+import os from "os";
 import { util } from "../src/index.js";
 
 const {
   CONTROLLER_ENV,
   CONTROLLER_APPLICATION_PREFIX,
+  PEWPEW_BINARY_EXECUTABLE,
+  PEWPEW_BINARY_EXECUTABLE_ARM,
+  PEWPEW_BINARY_EXECUTABLE_LINUX,
+  PEWPEW_BINARY_EXECUTABLE_MAC,
+  PEWPEW_BINARY_EXECUTABLE_WINDOWS,
   PREFIX_DEFAULT,
   createStatsFileName,
   getLocalIpAddress,
@@ -30,6 +36,23 @@ describe("Util", () => {
       const controllerEnv = "override";
       const prefix: string = getPrefix(controllerEnv);
       expect(prefix).to.equal(CONTROLLER_APPLICATION_PREFIX + controllerEnv.toUpperCase());
+      done();
+    });
+  });
+
+  describe("PEWPEW_BINARY_EXECUTABLE", () => {
+    it("should match the expected binary for the current platform/arch", (done: Mocha.Done) => {
+      let expected: string;
+      if (os.platform() === "win32") {
+        expected = PEWPEW_BINARY_EXECUTABLE_WINDOWS;
+      } else if (os.platform() === "darwin") {
+        expected = PEWPEW_BINARY_EXECUTABLE_MAC;
+      } else if (os.arch() === "arm64") {
+        expected = PEWPEW_BINARY_EXECUTABLE_ARM;
+      } else {
+        expected = PEWPEW_BINARY_EXECUTABLE_LINUX;
+      }
+      expect(PEWPEW_BINARY_EXECUTABLE).to.equal(expected);
       done();
     });
   });

--- a/controller/.github/workflows/pr.yml
+++ b/controller/.github/workflows/pr.yml
@@ -8,8 +8,9 @@ jobs:
     strategy:
       matrix:
         node-version: [22.x, 24.x]
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
       fail-fast: false
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
 
     steps:
       - uses: actions/checkout@v4

--- a/controller/.platform/hooks/predeploy/200_npm_rebuild.sh
+++ b/controller/.platform/hooks/predeploy/200_npm_rebuild.sh
@@ -20,7 +20,10 @@ npm install -D esbuild
 # (@next/swc-*, sharp) arrive with the wrong arch. Reinstalling next forces
 # npm to pick the correct optional binaries for the running instance.
 # Idempotent across x86 and arm64 instances.
-npm install --no-save next
+# Pin to the exact version from the lock file to avoid picking up a newer
+# release than what CI validated.
+NEXT_VERSION=$(node -p "require('./package-lock.json').packages['node_modules/next'].version")
+npm install --no-save "next@${NEXT_VERSION}"
 npm rebuild
 chmod a+x node_modules/.bin/*
 npm install -g rimraf

--- a/controller/acceptance/wdio/index.spec.ts
+++ b/controller/acceptance/wdio/index.spec.ts
@@ -98,17 +98,19 @@ describe("GET / (Test History Page)", () => {
       log("index.spec testDataWithResults", LogLevel.INFO, { testId: testDataWithResults?.testId });
     });
 
+    beforeEach(function () {
+      if (!testDataWithResults) { this.skip(); }
+    });
+
     it("should display the results dropdown for a test with results", async () => {
-      if (!testDataWithResults) { return; }
-      await browser.url(PAGE_TEST_HISTORY_FORMAT(testDataWithResults.testId));
+      await browser.url(PAGE_TEST_HISTORY_FORMAT(testDataWithResults!.testId));
       await assertNoPageError();
       const select = await $("[data-testid='results-select']");
       await expect(select).toExist();
     });
 
     it("selecting a result file should load the results", async () => {
-      if (!testDataWithResults) { return; }
-      await browser.url(PAGE_TEST_HISTORY_FORMAT(testDataWithResults.testId));
+      await browser.url(PAGE_TEST_HISTORY_FORMAT(testDataWithResults!.testId));
       await assertNoPageError();
       const select = await $("[data-testid='results-select']");
       await select.selectByIndex(1);
@@ -117,8 +119,7 @@ describe("GET / (Test History Page)", () => {
     });
 
     it("deselecting the result should hide the results", async () => {
-      if (!testDataWithResults) { return; }
-      await browser.url(PAGE_TEST_HISTORY_FORMAT(testDataWithResults.testId));
+      await browser.url(PAGE_TEST_HISTORY_FORMAT(testDataWithResults!.testId));
       await assertNoPageError();
       const select = await $("[data-testid='results-select']");
       await select.selectByIndex(1);
@@ -129,8 +130,7 @@ describe("GET / (Test History Page)", () => {
     });
 
     it("with ?results=0 should auto-select the first result and load it", async () => {
-      if (!testDataWithResults) { return; }
-      const url = `${PAGE_TEST_HISTORY_FORMAT(testDataWithResults.testId)}&results=0`;
+      const url = `${PAGE_TEST_HISTORY_FORMAT(testDataWithResults!.testId)}&results=0`;
       log(`navigating to ${url}`, LogLevel.DEBUG);
       await browser.url(url);
       await assertNoPageError();
@@ -139,8 +139,7 @@ describe("GET / (Test History Page)", () => {
     });
 
     it("selecting a result should update the URL to include results=0", async () => {
-      if (!testDataWithResults) { return; }
-      await browser.url(PAGE_TEST_HISTORY_FORMAT(testDataWithResults.testId));
+      await browser.url(PAGE_TEST_HISTORY_FORMAT(testDataWithResults!.testId));
       await assertNoPageError();
       const select = await $("[data-testid='results-select']");
       await select.selectByIndex(1);
@@ -153,8 +152,7 @@ describe("GET / (Test History Page)", () => {
     });
 
     it("deselecting should remove results= from the URL", async () => {
-      if (!testDataWithResults) { return; }
-      const url = `${PAGE_TEST_HISTORY_FORMAT(testDataWithResults.testId)}&results=0`;
+      const url = `${PAGE_TEST_HISTORY_FORMAT(testDataWithResults!.testId)}&results=0`;
       await browser.url(url);
       await assertNoPageError();
       const resultsLoaded = await $("[data-testid='results-loaded']");

--- a/controller/components/TestResults/index.tsx
+++ b/controller/components/TestResults/index.tsx
@@ -1200,7 +1200,7 @@ const FinalResultsTable = ({ displayData }: TableProps) => {
         </thead>
         <tbody>
           {tableData.map((row) => (
-            <DATATR key={`${row.method}-${row.hostname}-${row.path}-${row.tags}`}>
+            <DATATR key={`${row.method}-${row.hostname}-${row.path}-${row.queryString}-${row.tags}`}>
               <DATATD>{row.method}</DATATD>
               <DATATD title={row.hostname}>{row.hostname}</DATATD>
               <DATATD title={row.path}>{row.path}</DATATD>

--- a/controller/components/TestResults/testresults.spec.tsx
+++ b/controller/components/TestResults/testresults.spec.tsx
@@ -1,3 +1,11 @@
+vi.mock("axios", () => ({
+  default: {
+    get: vi.fn(() => Promise.resolve({ data: [] })),
+    put: vi.fn(() => Promise.resolve({ data: {} })),
+    delete: vi.fn(() => Promise.resolve({ data: {} }))
+  }
+}));
+vi.mock("next/router", () => ({ useRouter: () => ({ push: vi.fn(), replace: vi.fn(), pathname: "/", query: {} }) }));
 vi.mock("@fs/hdr-histogram-wasm", () => {
   function makeHist () {
     return {

--- a/controller/components/TestResultsCompare/testresultscompare.spec.tsx
+++ b/controller/components/TestResultsCompare/testresultscompare.spec.tsx
@@ -44,7 +44,7 @@ vi.mock("chart.js", () => {
 });
 
 import { BucketId, DataPoint, ParsedFileEntry } from "../TestResults/model";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import React from "react";
 import { TestResultsCompare } from ".";
 
@@ -215,6 +215,56 @@ describe("TestResultsCompare", () => {
       render(<TestResultsCompare baselineData={multiMethodData} comparisonData={multiMethodData} />);
       expect(screen.getByRole("option", { name: "GET" })).toBeInTheDocument();
       expect(screen.getByRole("option", { name: "POST" })).toBeInTheDocument();
+    });
+
+    it("FinalResultsTable shows 7 of 14 columns selected by default", () => {
+      render(<TestResultsCompare baselineData={baselineData} comparisonData={comparisonData} />);
+      fireEvent.click(screen.getByText("Final Results Comparison"));
+      expect(screen.getAllByText("7 of 14 columns selected").length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("toggling a column in one FinalResultsTable syncs the count in both", () => {
+      render(<TestResultsCompare baselineData={baselineData} comparisonData={comparisonData} />);
+      fireEvent.click(screen.getByText("Final Results Comparison"));
+      // Open the first table's column dropdown so its checkboxes become accessible
+      const [firstColumnBtn] = screen.getAllByRole("button", { name: /of 14 columns selected/ });
+      fireEvent.click(firstColumnBtn);
+      // Scope to the open dropdown container and click the first (Method) checkbox
+      const columnContainer = firstColumnBtn.closest(".column-select-container");
+      const [methodCheckbox] = within(columnContainer!).getAllByRole("checkbox");
+      fireEvent.click(methodCheckbox);
+      // Both tables share the same column visibility state
+      expect(screen.getAllByText("6 of 14 columns selected").length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("metrics dropdown shows 5 of 9 metrics selected by default", () => {
+      render(<TestResultsCompare baselineData={baselineData} comparisonData={comparisonData} />);
+      expect(screen.getByText("5 of 9 metrics selected")).toBeInTheDocument();
+    });
+
+    it("toggling a metric off decrements the visible metrics count", () => {
+      render(<TestResultsCompare baselineData={baselineData} comparisonData={comparisonData} />);
+      // Open the metrics dropdown so its checkboxes become accessible
+      const metricsBtn = screen.getByText("5 of 9 metrics selected").closest("button")!;
+      fireEvent.click(metricsBtn);
+      const metricsContainer = metricsBtn.closest(".metric-select-container");
+      // "Calls" is the first checkbox in the metrics dropdown (initially checked)
+      const [callsCheckbox] = within(metricsContainer!).getAllByRole("checkbox");
+      fireEvent.click(callsCheckbox);
+      expect(screen.getByText("4 of 9 metrics selected")).toBeInTheDocument();
+    });
+
+    it("toggling a metric on increments the visible metrics count", () => {
+      render(<TestResultsCompare baselineData={baselineData} comparisonData={comparisonData} />);
+      // Open the metrics dropdown so its checkboxes become accessible
+      const metricsBtn = screen.getByText("5 of 9 metrics selected").closest("button")!;
+      fireEvent.click(metricsBtn);
+      const metricsContainer = metricsBtn.closest(".metric-select-container");
+      // Checkboxes in order: calls(0), avg(1), min(2), max(3), stdDev(4), p50(5), p90(6), p95(7), p99(8)
+      // "min" is at index 2 and is initially unchecked
+      const metricCheckboxes = within(metricsContainer!).getAllByRole("checkbox");
+      fireEvent.click(metricCheckboxes[2]);
+      expect(screen.getByText("6 of 9 metrics selected")).toBeInTheDocument();
     });
   });
 });

--- a/controller/pages/index.tsx
+++ b/controller/pages/index.tsx
@@ -119,7 +119,7 @@ const TestStatusPage = ({
     const queryStr = params.toString();
     const newUrl = queryStr ? `${router.pathname}?${queryStr}` : router.pathname;
     log("router.push in updateQuery", LogLevel.DEBUG, { newUrl, pathname: router.pathname, query: router.query, asPath: router.asPath });
-    router.push(newUrl, formatPageHref(newUrl), { shallow: true });
+    router.push(newUrl, formatPageHref(newUrl), { shallow: true }).catch((error: unknown) => log("router.push error", LogLevel.ERROR, error));
   };
 
   const handleResultsIndexChange = (index: number | undefined): void => {
@@ -345,7 +345,8 @@ const TestStatusPage = ({
   // Before hydration (SSR), fall back to the server-rendered props so the initial render is
   // correct. Never fall back to SSR props post-hydration: a missing query param means the
   // user cleared that selection, not that the prop should be re-applied.
-  const resultsN = parseInt(typeof router.query.results === "string" ? router.query.results : "", 10);
+  const resultsStr = typeof router.query.results === "string" ? router.query.results : "";
+  const resultsN = /^\d+$/.test(resultsStr) ? parseInt(resultsStr, 10) : NaN;
   const currentResultsIndex = router.isReady ? (isNaN(resultsN) ? undefined : resultsN) : propsResultsIndex;
   const currentCompareTestId = router.isReady ? (typeof router.query.compare === "string" ? router.query.compare : undefined) : propsCompareTestId;
 
@@ -371,7 +372,7 @@ const TestStatusPage = ({
         {state.error && <Danger>Error: {state.error}</Danger>}
       </TestStatusSection>
       {testData && <TestResults
-        key={`${testData.testId}-${router.query.results ?? ""}-${router.query.compare ?? ""}`}
+        key={testData.testId}
         testData={testData}
         initialResultsIndex={currentResultsIndex}
         onResultsIndexChange={handleResultsIndexChange}
@@ -414,7 +415,8 @@ export const getServerSideProps: GetServerSideProps =
       // Convert it to json
       const testData: TestData = (testDataResponse as TestDataResponse).json;
 
-      const resultsParam = typeof ctx.query.results === "string" ? parseInt(ctx.query.results, 10) : NaN;
+      const resultsQueryStr = typeof ctx.query.results === "string" ? ctx.query.results : "";
+      const resultsParam = /^\d+$/.test(resultsQueryStr) ? parseInt(resultsQueryStr, 10) : NaN;
       return {
         props: {
           testData,


### PR DESCRIPTION
## Summary

Merges master (PR #380) into 0.6.0-scripting-dev.

One trivial conflict in `controller/.platform/hooks/predeploy/200_npm_rebuild.sh` — a trailing blank line on the scripting-dev side that wasn't in master. Resolved by keeping the master version.

## Changes from master (PR #380)

- Copilot feedback fixes: row key, TestResults remount, router.push catch, parseInt validation, acceptance test skip pattern
- Test improvements: testresults, testresultscompare, and util.spec.ts
- ARM64 CI runners added to agent/common/controller PR workflows
- Predeploy script pins `next` to lock file version
- `PEWPEW_BINARY_EXECUTABLE` nested ternary replaced with IIFE (SonarQube S3358)