### PR TITLE
PERF-4301 PPaaS - Investigate AuthApi on controller refresh cookie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ testmerge.json
 package-lock.json.scripting
 Cargo.lock.scripting
 CLAUDE.md
+tsconfig.tsbuildinfo

--- a/controller/src/authserver.ts
+++ b/controller/src/authserver.ts
@@ -379,7 +379,7 @@ export async function authApi (req: NextApiRequest, res: NextApiResponse, requir
           const { token: newToken, refreshToken: newRefreshToken, hintToken } = await getTokenFromRefreshToken(refreshToken);
           setCookiesOnApiResponse(req, res, newToken, newRefreshToken, hintToken);
           authPermissions = await validateToken(newToken);
-          log(`${req.method} ${req.url} refreshed authPermissions: ${JSON.stringify(authPermissions)}`, LogLevel.DEBUG);
+          log(`${req.method} ${req.url} refreshed authPermissions`, LogLevel.DEBUG, { ...authPermissions, token: undefined });
         } catch (refreshError) {
           log("Failed to refresh token in authApi", LogLevel.WARN, refreshError);
         }
@@ -434,6 +434,18 @@ const redirectToLogin = (ctx: GetServerSidePropsContext, error?: any): string =>
   return loginUrl;
 };
 
+function buildAuthCookies (domain: string, path: string, token: string, refreshToken?: string, hintToken?: string): string[] {
+  const oneDay: number = 60 * 60 * 24;
+  const cookies: string[] = [cookieSerialize(AUTH_COOKIE_NAME, token, { domain, path, maxAge: oneDay * COOKIE_DURATION_DAYS })];
+  if (refreshToken) {
+    cookies.push(cookieSerialize(REFRESH_COOKIE_NAME, refreshToken, { domain, path, maxAge: oneDay * REFRESH_COOKIE_DURATION_DAYS }));
+  }
+  if (hintToken) {
+    cookies.push(cookieSerialize(HINT_COOKIE_NAME, hintToken, { domain, path, maxAge: oneDay * COOKIE_DURATION_DAYS }));
+  }
+  return cookies;
+}
+
 // This can be called from the server
 export function setCookies (
   { ctx, token, refreshToken, hintToken }: {
@@ -444,19 +456,9 @@ export function setCookies (
   }) {
   const domain: string = getDomain(ctx.req);
   const path: string = getCookiePath(ctx.req) || "/";
-  log(`Set cookie to ${token} on ${domain}`, LogLevel.DEBUG);
-  // server side
-  const oneDay: number = 60 * 60 * 24;
+  log(`Set cookie on ${domain}`, LogLevel.DEBUG);
   try {
-    const cookies: string[] = [cookieSerialize(AUTH_COOKIE_NAME, token, { domain, path, maxAge: oneDay * COOKIE_DURATION_DAYS })];
-    if (refreshToken) {
-      cookies.push(cookieSerialize(REFRESH_COOKIE_NAME, refreshToken, { domain, path, maxAge: oneDay * REFRESH_COOKIE_DURATION_DAYS }));
-    }
-    if (hintToken) {
-      cookies.push(cookieSerialize(HINT_COOKIE_NAME, hintToken, { domain, path, maxAge: oneDay * COOKIE_DURATION_DAYS }));
-    }
-    // Set the cookie and then redirect
-    ctx.res.setHeader("Set-Cookie", cookies);
+    ctx.res.setHeader("Set-Cookie", buildAuthCookies(domain, path, token, refreshToken, hintToken));
   } catch (error: unknown) {
     log("Error setting cookies in header", LogLevel.WARN, error, { token: token !== undefined, refreshToken: refreshToken !== undefined, hintToken: hintToken !== undefined });
     throw error;
@@ -472,17 +474,9 @@ export function setCookiesOnApiResponse (
 ): void {
   const domain: string = getDomain(req);
   const path: string = getCookiePath(req) || "/";
-  log(`Set cookie to ${token} on ${domain}`, LogLevel.DEBUG);
-  const oneDay: number = 60 * 60 * 24;
+  log(`Set cookie on ${domain}`, LogLevel.DEBUG);
   try {
-    const cookies: string[] = [cookieSerialize(AUTH_COOKIE_NAME, token, { domain, path, maxAge: oneDay * COOKIE_DURATION_DAYS })];
-    if (refreshToken) {
-      cookies.push(cookieSerialize(REFRESH_COOKIE_NAME, refreshToken, { domain, path, maxAge: oneDay * REFRESH_COOKIE_DURATION_DAYS }));
-    }
-    if (hintToken) {
-      cookies.push(cookieSerialize(HINT_COOKIE_NAME, hintToken, { domain, path, maxAge: oneDay * COOKIE_DURATION_DAYS }));
-    }
-    res.setHeader("Set-Cookie", cookies);
+    res.setHeader("Set-Cookie", buildAuthCookies(domain, path, token, refreshToken, hintToken));
   } catch (error: unknown) {
     log("Error setting cookies on api response", LogLevel.WARN, error, { token: token !== undefined, refreshToken: refreshToken !== undefined, hintToken: hintToken !== undefined });
     throw error;

--- a/controller/src/authserver.ts
+++ b/controller/src/authserver.ts
@@ -369,11 +369,25 @@ export async function authApi (req: NextApiRequest, res: NextApiResponse, requir
       return undefined;
     }
 
-    const authPermissions: AuthPermissions = await validateToken(token);
+    let authPermissions: AuthPermissions = await validateToken(token);
     log(`${req.method} ${req.url} authPermissions: ${JSON.stringify(authPermissions)}`, LogLevel.DEBUG);
-    // If it's expired redirect to login
+    // If expired, attempt a silent refresh before giving up
     if (authPermissions.authPermission === AuthPermission.Expired) {
-      res.status(401).json({ message: "Session Expired. Please login again." });
+      const refreshToken: string | undefined = getTokenFromQueryOrHeader(req, REFRESH_COOKIE_NAME);
+      if (refreshToken) {
+        try {
+          const { token: newToken, refreshToken: newRefreshToken, hintToken } = await getTokenFromRefreshToken(refreshToken);
+          setCookiesOnApiResponse(req, res, newToken, newRefreshToken, hintToken);
+          authPermissions = await validateToken(newToken);
+          log(`${req.method} ${req.url} refreshed authPermissions: ${JSON.stringify(authPermissions)}`, LogLevel.DEBUG);
+        } catch (refreshError) {
+          log("Failed to refresh token in authApi", LogLevel.WARN, refreshError);
+        }
+      }
+    }
+    // If still expired after refresh attempt (or no refresh token available), return 401
+    if (authPermissions.authPermission === AuthPermission.Expired) {
+      res.status(401).json({ message: SESSION_EXPIRED_MESSAGE });
       return undefined;
     }
     // If we don't have permissions or the permissions are not greater than requiredPermissions
@@ -445,6 +459,32 @@ export function setCookies (
     ctx.res.setHeader("Set-Cookie", cookies);
   } catch (error: unknown) {
     log("Error setting cookies in header", LogLevel.WARN, error, { token: token !== undefined, refreshToken: refreshToken !== undefined, hintToken: hintToken !== undefined });
+    throw error;
+  }
+}
+
+export function setCookiesOnApiResponse (
+  req: NextApiRequest,
+  res: NextApiResponse,
+  token: string,
+  refreshToken?: string,
+  hintToken?: string
+): void {
+  const domain: string = getDomain(req);
+  const path: string = getCookiePath(req) || "/";
+  log(`Set cookie to ${token} on ${domain}`, LogLevel.DEBUG);
+  const oneDay: number = 60 * 60 * 24;
+  try {
+    const cookies: string[] = [cookieSerialize(AUTH_COOKIE_NAME, token, { domain, path, maxAge: oneDay * COOKIE_DURATION_DAYS })];
+    if (refreshToken) {
+      cookies.push(cookieSerialize(REFRESH_COOKIE_NAME, refreshToken, { domain, path, maxAge: oneDay * REFRESH_COOKIE_DURATION_DAYS }));
+    }
+    if (hintToken) {
+      cookies.push(cookieSerialize(HINT_COOKIE_NAME, hintToken, { domain, path, maxAge: oneDay * COOKIE_DURATION_DAYS }));
+    }
+    res.setHeader("Set-Cookie", cookies);
+  } catch (error: unknown) {
+    log("Error setting cookies on api response", LogLevel.WARN, error, { token: token !== undefined, refreshToken: refreshToken !== undefined, hintToken: hintToken !== undefined });
     throw error;
   }
 }


### PR DESCRIPTION
## Summary

- When `authApi` detects an expired token, attempt a silent token refresh using the refresh cookie before returning 401
- New `setCookiesOnApiResponse` helper sets updated auth/refresh/hint cookies on the API response so the browser picks them up transparently
- If no refresh token is present or the refresh fails, the original 401 behavior is preserved

## Problem

API calls were failing with 401/403 when a session expired. Page navigations already handled silent refresh via `pages/login.tsx`, but API routes had no equivalent — any in-flight or post-expiry API call would fail until the user navigated to a page and triggered the login redirect.

## Solution

In `authApi`, after detecting `AuthPermission.Expired`:
1. Look for a refresh token in the request (cookie/header)
2. If found, call `getTokenFromRefreshToken` and set new cookies on the response via `setCookiesOnApiResponse`
3. Re-validate the new token and continue with the request
4. Fall back to 401 if no refresh token exists or the refresh itself fails

## Test plan

- [x] Verify API calls succeed transparently after session expiry when a valid refresh token cookie is present
- [x] Verify the response includes `Set-Cookie` headers with the new auth/refresh tokens
- [x] Verify 401 is still returned when no refresh token is present
- [x] Verify 401 is still returned when the refresh token is expired/invalid