### PR TITLE
PERF-4222 Results Viewer - add hash/anchor links to TestResults and TestResultsCompare

### DIFF
--- a/controller/components/TestResults/index.tsx
+++ b/controller/components/TestResults/index.tsx
@@ -21,13 +21,14 @@ import {
   EndpointDiv2,
   FlexRow,
   H3,
+  HashAnchorLink,
   RttDiv,
   RttTable,
   StyledUl
 } from "./styled";
 import { HtmlTable, HtmlTd, HtmlTr } from "../Table";
 import { LogLevel, log } from "../../src/log";
-import { MinMaxTime, comprehensiveSort, minMaxTime, parseResultsData } from "./utils";
+import { MinMaxTime, bucketAnchorId, comprehensiveSort, minMaxTime, parseResultsData } from "./utils";
 import { ModalObject, TestsListModal, useEffectModal } from "../Modal";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { TestData, TestManagerError, TestManagerMessage } from "../../types/testmanager";
@@ -243,6 +244,52 @@ const DownloadButton = styled.button`
   }
 `;
 
+const SectionHeading = styled.h1`
+  a.anchor-link {
+    margin-left: 0.4em;
+    color: #666;
+    text-decoration: none;
+    font-size: 0.7em;
+    vertical-align: middle;
+    opacity: 0;
+    transition: opacity 0.15s;
+
+    &:hover {
+      color: #6a7bb4;
+    }
+  }
+
+  &:hover a.anchor-link {
+    opacity: 1;
+  }
+`;
+
+const SectionHeadingH2 = styled.h2`
+  a.anchor-link {
+    margin-left: 0.4em;
+    color: #666;
+    text-decoration: none;
+    font-size: 0.7em;
+    vertical-align: middle;
+    opacity: 0;
+    transition: opacity 0.15s;
+
+    &:hover {
+      color: #6a7bb4;
+    }
+  }
+
+  &:hover a.anchor-link {
+    opacity: 1;
+  }
+`;
+
+const handleAnchorClick = (e: React.MouseEvent<HTMLAnchorElement>, id: string) => {
+  e.preventDefault();
+  history.replaceState(null, "", "#" + id);
+  document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
+};
+
 export interface TestResultProps {
   testData: TestData;
   /** Auto-select this results index (0-based) on mount */
@@ -287,6 +334,7 @@ export interface TestResultState {
 export interface EndpointProps {
   bucketId: BucketId;
   dataPoints: DataPoint[];
+  anchorId: string;
 }
 
 /** Let's us override for Storybook to use static files */
@@ -950,6 +998,22 @@ export const TestResults = React.memo(({ testData, initialResultsIndex, onResult
     return displayData.filter(([bucketId]) => bucketId.method === methodFilter);
   }, [displayData, methodFilter]);
 
+  const initialScrollDoneRef = useRef(false);
+  useEffect(() => {
+    if (filteredDisplayData === undefined) {
+      initialScrollDoneRef.current = false;
+      return;
+    }
+    if (initialScrollDoneRef.current) { return; }
+    initialScrollDoneRef.current = true;
+    const hash = window.location.hash.slice(1);
+    if (!hash) { return; }
+    const timer = setTimeout(() => {
+      document.getElementById(hash)?.scrollIntoView({ behavior: "smooth" });
+    }, 100);
+    return () => clearTimeout(timer);
+  }, [filteredDisplayData]);
+
   log("displayData", LogLevel.DEBUG, { displayData: displayData?.length, filteredData: state.filteredData?.length, resultsData: state.resultsData?.length });
   return (
     <React.Fragment>
@@ -977,7 +1041,12 @@ export const TestResults = React.memo(({ testData, initialResultsIndex, onResult
         )}
       {filteredDisplayData !== undefined ? (
         <TimeTaken data-testid="results-loaded">
-          <h1>Time Taken</h1>
+          <div id="time-taken">
+            <SectionHeading>
+              Time Taken
+              <a href="#time-taken" className="anchor-link" onClick={(e) => handleAnchorClick(e, "time-taken")}>#</a>
+            </SectionHeading>
+          </div>
           <p>
             {state.minMaxTime?.startTime} to {state.minMaxTime?.endTime}
           </p>
@@ -993,7 +1062,12 @@ export const TestResults = React.memo(({ testData, initialResultsIndex, onResult
             baselineLabel={state.compareTest?.testId}
             comparisonLabel={testData.testId}
           />}
-          <h1>Overview charts</h1>
+          <div id="overview-charts">
+            <SectionHeading>
+              Overview charts
+              <a href="#overview-charts" className="anchor-link" onClick={(e) => handleAnchorClick(e, "overview-charts")}>#</a>
+            </SectionHeading>
+          </div>
           <p>Filter which endpoints are included in the summary:</p>
           <label htmlFor="summaryTagFilter">
             <span>Tag name</span>
@@ -1038,16 +1112,32 @@ export const TestResults = React.memo(({ testData, initialResultsIndex, onResult
             </ToggleContainer>
           </FilterContainer>
 
-          <h2>Performance & Error Metrics</h2>
+          <div id="performance-metrics">
+            <SectionHeadingH2>
+              Performance &amp; Error Metrics
+              <a href="#performance-metrics" className="anchor-link" onClick={(e) => handleAnchorClick(e, "performance-metrics")}>#</a>
+            </SectionHeadingH2>
+          </div>
           <QuadPanelCharts displayData={filteredDisplayData} mergeEndpoints={mergeEndpoints} />
 
-          <h1>Final Results</h1>
+          <div id="final-results">
+            <SectionHeading>
+              Final Results
+              <a href="#final-results" className="anchor-link" onClick={(e) => handleAnchorClick(e, "final-results")}>#</a>
+            </SectionHeading>
+          </div>
           <FinalResultsTable displayData={filteredDisplayData} />
 
-          <h1>Endpoint Data</h1>
-          {filteredDisplayData.map(([bucketId, dataPoints]) => {
+          <div id="endpoint-data">
+            <SectionHeading>
+              Endpoint Data
+              <a href="#endpoint-data" className="anchor-link" onClick={(e) => handleAnchorClick(e, "endpoint-data")}>#</a>
+            </SectionHeading>
+          </div>
+          {filteredDisplayData.map(([bucketId, dataPoints], index) => {
+            const anchorId = bucketAnchorId(bucketId, index);
             return (
-              <Endpoint key={JSON.stringify(bucketId)} bucketId={bucketId} dataPoints={dataPoints} />
+              <Endpoint key={JSON.stringify(bucketId)} bucketId={bucketId} dataPoints={dataPoints} anchorId={anchorId} />
             );
           })}
         </TimeTaken>
@@ -1067,7 +1157,7 @@ const FinalResultsTable = ({ displayData }: TableProps) => {
   const tableData = useMemo(() => {
     const results: any[] = [];
 
-    for (const [bucketId, dataPoints] of displayData) {
+    for (const [index, [bucketId, dataPoints]] of displayData.entries()) {
       if (dataPoints.length === 0) { continue; }
 
       // Aggregate all datapoints for this endpoint
@@ -1118,6 +1208,7 @@ const FinalResultsTable = ({ displayData }: TableProps) => {
       const tagsString = JSON.stringify(otherTags);
 
       results.push({
+        anchorId: bucketAnchorId(bucketId, index),
         method: bucketId.method,
         hostname,
         path,
@@ -1182,6 +1273,7 @@ const FinalResultsTable = ({ displayData }: TableProps) => {
         <DataTable>
         <thead>
           <tr>
+            <Th style={{ width: "24px", padding: "8px 4px" }}></Th>
             <Th>method</Th>
             <Th>hostname</Th>
             <Th>path</Th>
@@ -1201,6 +1293,14 @@ const FinalResultsTable = ({ displayData }: TableProps) => {
         <tbody>
           {tableData.map((row) => (
             <DataTr key={`${row.method}-${row.hostname}-${row.path}-${row.queryString}-${row.tags}`}>
+              <DataTd style={{ padding: "6px 4px", textAlign: "center" }}>
+                <a
+                  href={`#${row.anchorId}`}
+                  title="Jump to endpoint detail"
+                  style={{ color: "#666", textDecoration: "none", fontSize: "0.85em" }}
+                  onClick={(e) => handleAnchorClick(e, row.anchorId)}
+                >#</a>
+              </DataTd>
               <DataTd>{row.method}</DataTd>
               <DataTd title={row.hostname}>{row.hostname}</DataTd>
               <DataTd title={row.path}>{row.path}</DataTd>
@@ -1295,7 +1395,7 @@ const total = (dataPoints: DataPoint[]) => {
   }
 };
 
-const Endpoint = React.memo(({ bucketId, dataPoints }: EndpointProps) => {
+const Endpoint = React.memo(({ bucketId, dataPoints, anchorId }: EndpointProps) => {
   const [rttButtonDisplay, setRttButtonDisplay] = useState("");
   const [totalButtonDisplay, setTotalButtonDisplay] = useState("");
 
@@ -1368,9 +1468,10 @@ const Endpoint = React.memo(({ bucketId, dataPoints }: EndpointProps) => {
 
   return (
     <React.Fragment>
-      <EndpointDiv>
+      <EndpointDiv id={anchorId}>
         <H3>
           {bucketId.method} {bucketId.url}
+          <HashAnchorLink href={`#${anchorId}`} onClick={(e) => handleAnchorClick(e, anchorId)}>#</HashAnchorLink>
         </H3>
         <StyledUl>
           {Object.entries(bucketId).map(([key, value]) => {

--- a/controller/components/TestResults/styled.tsx
+++ b/controller/components/TestResults/styled.tsx
@@ -5,9 +5,27 @@ export const EndpointDiv = styled.div`
   padding: 0;
 `;
 
+export const HashAnchorLink = styled.a`
+  margin-left: 0.4em;
+  color: #666;
+  text-decoration: none;
+  font-size: 0.75em;
+  vertical-align: middle;
+  opacity: 0;
+  transition: opacity 0.15s;
+
+  &:hover {
+    color: #6a7bb4;
+  }
+`;
+
 export const H3 = styled.h3`
   text-align: left;
   word-break: break-all;
+
+  &:hover ${HashAnchorLink} {
+    opacity: 1;
+  }
 `;
 
 export const EndpointDiv1 = styled.div`

--- a/controller/components/TestResults/utils.spec.ts
+++ b/controller/components/TestResults/utils.spec.ts
@@ -3,7 +3,7 @@ vi.mock("./model", () => ({
   processNewJson: vi.fn(() => [])
 }));
 
-import { comprehensiveSort, dateToString, formatValue, minMaxTime, parseResultsData } from "./utils";
+import { bucketAnchorId, compareEndpointAnchorId, comprehensiveSort, dateToString, formatValue, minMaxTime, parseResultsData } from "./utils";
 import { processJson, processNewJson } from "./model";
 
 describe("utils", () => {
@@ -191,6 +191,42 @@ describe("utils", () => {
     it("returns an empty array when processJson returns no entries", async () => {
       const result = await parseResultsData(JSON.stringify({ buckets: [] }));
       expect(result).toEqual([]);
+    });
+  });
+
+  describe("bucketAnchorId", () => {
+    it("uses _id tag when present", () => {
+      expect(bucketAnchorId({ method: "GET", url: "http://example.com", _id: "3" }, 99)).toBe("endpoint-3");
+    });
+
+    it("uses _id tag of '0' (not falsy-coerced to index)", () => {
+      expect(bucketAnchorId({ method: "GET", url: "http://example.com", _id: "0" }, 5)).toBe("endpoint-0");
+    });
+
+    it("falls back to index when _id is absent", () => {
+      expect(bucketAnchorId({ method: "GET", url: "http://example.com" }, 5)).toBe("endpoint-5");
+    });
+
+    it("falls back to index 0 when _id is absent and index is 0", () => {
+      expect(bucketAnchorId({ method: "POST", url: "http://example.com" }, 0)).toBe("endpoint-0");
+    });
+
+    it("prefixes with 'endpoint-'", () => {
+      expect(bucketAnchorId({ method: "GET", url: "/api", _id: "7" }, 0)).toMatch(/^endpoint-/);
+    });
+  });
+
+  describe("compareEndpointAnchorId", () => {
+    it("generates compare-endpoint-0 for index 0", () => {
+      expect(compareEndpointAnchorId(0)).toBe("compare-endpoint-0");
+    });
+
+    it("generates compare-endpoint-7 for index 7", () => {
+      expect(compareEndpointAnchorId(7)).toBe("compare-endpoint-7");
+    });
+
+    it("prefixes with 'compare-endpoint-'", () => {
+      expect(compareEndpointAnchorId(3)).toMatch(/^compare-endpoint-/);
     });
   });
 });

--- a/controller/components/TestResults/utils.ts
+++ b/controller/components/TestResults/utils.ts
@@ -1,4 +1,4 @@
-import { ParsedFileEntry } from "./model";
+import { BucketId, ParsedFileEntry } from "./model";
 
 export interface MinMaxTime {
   startTime?: string;
@@ -127,3 +127,12 @@ export const parseResultsData = async (text: string): Promise<ParsedFileEntry[]>
 export const formatValue = (value: number, unit: string = ""): string => {
   return `${value.toLocaleString()}${unit}`;
 };
+
+/** Generates a stable anchor ID for an endpoint based on its _id tag or fallback index */
+export const bucketAnchorId = (bucketId: BucketId, index: number): string => {
+  const id = bucketId._id !== undefined ? String(bucketId._id) : String(index);
+  return `endpoint-${id}`;
+};
+
+/** Generates an anchor ID for an endpoint comparison section by its index */
+export const compareEndpointAnchorId = (index: number): string => `compare-endpoint-${index}`;

--- a/controller/components/TestResultsCompare/index.tsx
+++ b/controller/components/TestResultsCompare/index.tsx
@@ -14,6 +14,7 @@ import * as XLSX from "xlsx";
 import { DataPoint, ParsedFileEntry } from "../TestResults/model";
 import { Chart } from "chart.js";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { compareEndpointAnchorId } from "../TestResults/utils";
 import styled from "styled-components";
 /* eslint-enable sort-imports */
 
@@ -379,6 +380,32 @@ const DropdownItem = styled.label`
     height: 14px;
   }
 `;
+
+const SectionHeading = styled.h2`
+  a.anchor-link {
+    margin-left: 0.4em;
+    color: #666;
+    text-decoration: none;
+    font-size: 0.7em;
+    vertical-align: middle;
+    opacity: 0;
+    transition: opacity 0.15s;
+
+    &:hover {
+      color: #6a7bb4;
+    }
+  }
+
+  &:hover a.anchor-link {
+    opacity: 1;
+  }
+`;
+
+const handleAnchorClick = (e: React.MouseEvent<HTMLAnchorElement>, id: string) => {
+  e.preventDefault();
+  history.replaceState(null, "", "#" + id);
+  document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
+};
 
 // ============================================================================
 // Shared state shape constants
@@ -901,6 +928,27 @@ export const TestResultsCompare: React.FC<TestResultsCompareProps> = ({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
+  const initialScrollDoneRef = useRef(false);
+  useEffect(() => {
+    if (!baselineData?.length || !comparisonData?.length) {
+      initialScrollDoneRef.current = false;
+      return;
+    }
+    if (initialScrollDoneRef.current) { return; }
+    initialScrollDoneRef.current = true;
+    const hash = window.location.hash.slice(1);
+    if (!hash) { return; }
+    if (hash === "compare-final-results") {
+      setActiveTab("final");
+    } else if (hash.startsWith("compare-endpoint-") || hash === "compare-overview-charts") {
+      setActiveTab("endpoint");
+    }
+    const timer = setTimeout(() => {
+      document.getElementById(hash)?.scrollIntoView({ behavior: "smooth" });
+    }, 100);
+    return () => clearTimeout(timer);
+  }, [baselineData, comparisonData]);
+
   // Extract unique HTTP methods from both datasets
   const availableMethods = useMemo(() => {
     const methods = new Set<string>();
@@ -993,7 +1041,12 @@ export const TestResultsCompare: React.FC<TestResultsCompareProps> = ({
         </ToggleContainer>
       </FilterContainer>
 
-      <H2>Performance & Error Metrics Comparison</H2>
+      <div id="compare-overview-charts">
+        <SectionHeading>
+          Performance &amp; Error Metrics Comparison
+          <a href="#compare-overview-charts" className="anchor-link" onClick={(e) => handleAnchorClick(e, "compare-overview-charts")}>#</a>
+        </SectionHeading>
+      </div>
       <ComparisonChartsGrid>
         <ChartColumn>
           <div>
@@ -1115,6 +1168,12 @@ export const TestResultsCompare: React.FC<TestResultsCompareProps> = ({
 
       {activeTab === "endpoint" && (
         <TabContent>
+          <div id="compare-endpoint-comparison">
+            <SectionHeading>
+              Endpoint Comparison
+              <a href="#compare-endpoint-comparison" className="anchor-link" onClick={(e) => handleAnchorClick(e, "compare-endpoint-comparison")}>#</a>
+            </SectionHeading>
+          </div>
           <p style={{ textAlign: "center", color: "#999", marginBottom: "1em" }}>
             Per-endpoint metrics comparison (green = improvement, red = regression)
           </p>
@@ -1244,7 +1303,7 @@ export const TestResultsCompare: React.FC<TestResultsCompareProps> = ({
               );
             };
 
-            return matchedEndpoints.map(({ key, method, url, baselineData: endpointBaselineData, comparisonData: endpointComparisonData }) => {
+            return matchedEndpoints.map(({ key, method, url, baselineData: endpointBaselineData, comparisonData: endpointComparisonData }, endpointIndex) => {
               // Aggregate baseline data for this endpoint
               let baselineRTT = null;
               let baselineCallCount = 0;
@@ -1304,11 +1363,13 @@ export const TestResultsCompare: React.FC<TestResultsCompareProps> = ({
                 comparisonRTT.free();
               }
 
+              const endpointAnchorId = compareEndpointAnchorId(endpointIndex);
               return (
-                <div key={key} style={{ marginBottom: "3em" }}>
-                  <H2 style={{ fontSize: "1.2em", marginBottom: "0.5em" }}>
+                <div key={key} id={endpointAnchorId} style={{ marginBottom: "3em" }}>
+                  <SectionHeading style={{ fontSize: "1.2em", marginBottom: "0.5em" }}>
                     {method} {url}
-                  </H2>
+                    <a href={`#${endpointAnchorId}`} className="anchor-link" onClick={(e) => handleAnchorClick(e, endpointAnchorId)}>#</a>
+                  </SectionHeading>
                   <TableContainer>
                     <DataTable>
                       <thead>
@@ -1341,6 +1402,12 @@ export const TestResultsCompare: React.FC<TestResultsCompareProps> = ({
 
       {activeTab === "final" && (
         <TabContent>
+          <div id="compare-final-results">
+            <SectionHeading>
+              Final Results Comparison
+              <a href="#compare-final-results" className="anchor-link" onClick={(e) => handleAnchorClick(e, "compare-final-results")}>#</a>
+            </SectionHeading>
+          </div>
           <ComparisonChartsGrid>
             <ChartColumn>
               <H2>{baselineLabel}</H2>

--- a/controller/components/TestResultsCompare/testresultscompare.spec.tsx
+++ b/controller/components/TestResultsCompare/testresultscompare.spec.tsx
@@ -149,8 +149,8 @@ describe("TestResultsCompare", () => {
 
     it("shows tab navigation buttons", () => {
       render(<TestResultsCompare baselineData={baselineData} comparisonData={comparisonData} />);
-      expect(screen.getByText("Endpoint Comparison")).toBeInTheDocument();
-      expect(screen.getByText("Final Results Comparison")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Endpoint Comparison" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Final Results Comparison" })).toBeInTheDocument();
     });
 
     it("shows endpoint comparison content by default", () => {

--- a/guide/results-viewer-react/src/components/TestResults/index.tsx
+++ b/guide/results-viewer-react/src/components/TestResults/index.tsx
@@ -1,9 +1,9 @@
 import * as XLSX from "xlsx";
 import { BucketId, DataPoint, ParsedFileEntry } from "./model";
 import { LogLevel, formatError, log } from "../../util/log";
-import { MinMaxTime, comprehensiveSort, minMaxTime, parseResultsData } from "./utils";
+import { MinMaxTime, bucketAnchorId, comprehensiveSort, minMaxTime, parseResultsData } from "./utils";
 // Dynamic import for charts to reduce bundle size
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Chart } from "chart.js";
 import { Danger } from "../Alert";
 import styled from "styled-components";
@@ -75,6 +75,52 @@ export const TR = styled.tr`
     background: #474747;
   };
 `;
+
+const SectionHeadingH1 = styled.h1`
+  a.anchor-link {
+    margin-left: 0.4em;
+    color: #666;
+    text-decoration: none;
+    font-size: 0.7em;
+    vertical-align: middle;
+    opacity: 0;
+    transition: opacity 0.15s;
+
+    &:hover {
+      color: #6a7bb4;
+    }
+  }
+
+  &:hover a.anchor-link {
+    opacity: 1;
+  }
+`;
+
+const SectionHeadingH2 = styled.h2`
+  a.anchor-link {
+    margin-left: 0.4em;
+    color: #666;
+    text-decoration: none;
+    font-size: 0.7em;
+    vertical-align: middle;
+    opacity: 0;
+    transition: opacity 0.15s;
+
+    &:hover {
+      color: #6a7bb4;
+    }
+  }
+
+  &:hover a.anchor-link {
+    opacity: 1;
+  }
+`;
+
+const handleAnchorClick = (e: React.MouseEvent<HTMLAnchorElement>, id: string) => {
+  e.preventDefault();
+  history.replaceState(null, "", "#" + id);
+  document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
+};
 
 export interface TestResultProps {
   resultsText: string;
@@ -352,13 +398,34 @@ export const TestResults = React.memo(({ resultsText }: TestResultProps) => {
   //     : { method: getSummaryDisplay({ summaryTagFilter: "", summaryTagValueFilter: "" }), url: "" };
   // }, [state.summaryData, state.filteredData]);
 
+  const initialScrollDoneRef = useRef(false);
+  useEffect(() => {
+    if (!filteredDisplayData) {
+      initialScrollDoneRef.current = false;
+      return;
+    }
+    if (initialScrollDoneRef.current) { return; }
+    initialScrollDoneRef.current = true;
+    const hash = window.location.hash.slice(1);
+    if (!hash) { return; }
+    const timer = setTimeout(() => {
+      document.getElementById(hash)?.scrollIntoView({ behavior: "smooth" });
+    }, 100);
+    return () => clearTimeout(timer);
+  }, [filteredDisplayData]);
+
   log("displayData", LogLevel.DEBUG, { displayData: displayData?.length, filteredData: state.filteredData?.length, resultsData: state.resultsData?.length });
   return (
     <React.Fragment>
       {state.error && <Danger>{state.error}</Danger>}
       {filteredDisplayData !== undefined ? (
         <TIMETAKEN>
-          <h1>Time Taken</h1>
+          <div id="time-taken">
+            <SectionHeadingH1>
+              Time Taken
+              <a href="#time-taken" className="anchor-link" onClick={(e) => handleAnchorClick(e, "time-taken")}>#</a>
+            </SectionHeadingH1>
+          </div>
           <p>
             {state.minMaxTime?.startTime} to {state.minMaxTime?.endTime}
           </p>
@@ -394,14 +461,25 @@ export const TestResults = React.memo(({ resultsText }: TestResultProps) => {
             </TOGGLECONTAINER>
           </FILTERCONTAINER>
 
-          <h1>Request Count by Endpoint</h1>
+          <div id="overview-charts">
+            <SectionHeadingH1>
+              Overview Charts
+              <a href="#overview-charts" className="anchor-link" onClick={(e) => handleAnchorClick(e, "overview-charts")}>#</a>
+            </SectionHeadingH1>
+          </div>
+          <h2>Request Count by Endpoint</h2>
           <OverviewChart displayData={filteredDisplayData} mergeEndpoints={mergeEndpoints} />
-          <h1>Request Count by Host</h1>
+          <h2>Request Count by Host</h2>
           <HostChart displayData={filteredDisplayData} />
-          <h1>Request Count by Agent</h1>
+          <h2>Request Count by Agent</h2>
           <AgentChart displayData={filteredDisplayData} />
 
-          <h1>Performance & Error Metrics</h1>
+          <div id="performance-metrics">
+            <SectionHeadingH2>
+              Performance &amp; Error Metrics
+              <a href="#performance-metrics" className="anchor-link" onClick={(e) => handleAnchorClick(e, "performance-metrics")}>#</a>
+            </SectionHeadingH2>
+          </div>
           <QUADGRID>
             <QUADPANEL>
               <h3>Median Duration by Path</h3>
@@ -421,7 +499,12 @@ export const TestResults = React.memo(({ resultsText }: TestResultProps) => {
             </QUADPANEL>
           </QUADGRID>
 
-          <h1>Final Results</h1>
+          <div id="final-results">
+            <SectionHeadingH1>
+              Final Results
+              <a href="#final-results" className="anchor-link" onClick={(e) => handleAnchorClick(e, "final-results")}>#</a>
+            </SectionHeadingH1>
+          </div>
           <FinalResultsTable displayData={filteredDisplayData} />
         </TIMETAKEN>
       ) : (
@@ -1251,7 +1334,7 @@ const FinalResultsTable = ({ displayData }: TableProps) => {
   const tableData = useMemo(() => {
     const results: any[] = [];
 
-    for (const [bucketId, dataPoints] of displayData) {
+    for (const [index, [bucketId, dataPoints]] of displayData.entries()) {
       if (dataPoints.length === 0) {continue;}
 
       // Aggregate all datapoints for this endpoint
@@ -1308,6 +1391,7 @@ const FinalResultsTable = ({ displayData }: TableProps) => {
       const tagsString = JSON.stringify(otherTags);
 
       results.push({
+        anchorId: bucketAnchorId(bucketId, index),
         method: bucketId.method,
         hostname,
         path,
@@ -1369,6 +1453,7 @@ const FinalResultsTable = ({ displayData }: TableProps) => {
         <DATATABLE>
         <thead>
           <tr>
+            <TH style={{ width: "24px", padding: "8px 4px" }}></TH>
             <TH>method</TH>
             <TH>hostname</TH>
             <TH>path</TH>
@@ -1387,7 +1472,15 @@ const FinalResultsTable = ({ displayData }: TableProps) => {
         </thead>
         <tbody>
           {tableData.map((row, idx) => (
-            <DATATR key={idx}>
+            <DATATR key={idx} id={row.anchorId}>
+              <DATATD style={{ padding: "6px 4px", textAlign: "center" }}>
+                <a
+                  href={`#${row.anchorId}`}
+                  title="Link to this endpoint"
+                  style={{ color: "#666", textDecoration: "none", fontSize: "0.85em" }}
+                  onClick={(e) => handleAnchorClick(e, row.anchorId)}
+                >#</a>
+              </DATATD>
               <DATATD>{row.method}</DATATD>
               <DATATD title={row.hostname}>{row.hostname}</DATATD>
               <DATATD title={row.path}>{row.path}</DATATD>

--- a/guide/results-viewer-react/src/components/TestResults/utils.ts
+++ b/guide/results-viewer-react/src/components/TestResults/utils.ts
@@ -1,4 +1,4 @@
-import type { ParsedFileEntry } from "./model";
+import type { BucketId, ParsedFileEntry } from "./model";
 
 export interface MinMaxTime {
   startTime?: string;
@@ -127,3 +127,12 @@ export const parseResultsData = async (text: string): Promise<ParsedFileEntry[]>
 export const formatValue = (value: number, unit: string = ""): string => {
   return `${value.toLocaleString()}${unit}`;
 };
+
+/** Generates a stable anchor ID for an endpoint based on its _id tag or fallback index */
+export const bucketAnchorId = (bucketId: BucketId, index: number): string => {
+  const id = bucketId._id !== undefined ? String(bucketId._id) : String(index);
+  return `endpoint-${id}`;
+};
+
+/** Generates an anchor ID for an endpoint comparison section by its index */
+export const compareEndpointAnchorId = (index: number): string => `compare-endpoint-${index}`;

--- a/guide/results-viewer-react/src/components/TestResultsCompare/index.tsx
+++ b/guide/results-viewer-react/src/components/TestResultsCompare/index.tsx
@@ -13,8 +13,8 @@ import * as XLSX from "xlsx";
 import { ComparisonResult, compareResults } from "../TestResults/comparison";
 import { DataPoint, ParsedFileEntry } from "../TestResults/model";
 import { LogLevel, formatError, log } from "../../util/log";
-import { MinMaxTime, comprehensiveSort, minMaxTime, parseResultsData } from "../TestResults/utils";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { MinMaxTime, compareEndpointAnchorId, comprehensiveSort, minMaxTime, parseResultsData } from "../TestResults/utils";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Chart } from "chart.js";
 import { Danger } from "../Alert";
 import styled from "styled-components";
@@ -402,6 +402,52 @@ const DROPDOWNITEM = styled.label`
     height: 14px;
   }
 `;
+
+const SectionHeadingH1 = styled.h1`
+  a.anchor-link {
+    margin-left: 0.4em;
+    color: #666;
+    text-decoration: none;
+    font-size: 0.7em;
+    vertical-align: middle;
+    opacity: 0;
+    transition: opacity 0.15s;
+
+    &:hover {
+      color: #6a7bb4;
+    }
+  }
+
+  &:hover a.anchor-link {
+    opacity: 1;
+  }
+`;
+
+const SectionHeadingH2 = styled.h2`
+  a.anchor-link {
+    margin-left: 0.4em;
+    color: #666;
+    text-decoration: none;
+    font-size: 0.7em;
+    vertical-align: middle;
+    opacity: 0;
+    transition: opacity 0.15s;
+
+    &:hover {
+      color: #6a7bb4;
+    }
+  }
+
+  &:hover a.anchor-link {
+    opacity: 1;
+  }
+`;
+
+const handleAnchorClick = (e: React.MouseEvent<HTMLAnchorElement>, id: string) => {
+  e.preventDefault();
+  history.replaceState(null, "", "#" + id);
+  document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
+};
 
 // ============================================================================
 // TypeScript Interfaces
@@ -1251,6 +1297,27 @@ export const TestResultsCompare: React.FC<TestResultsCompareProps> = React.memo(
     loadData();
   }, [baselineText, comparisonText]);
 
+  const initialScrollDoneRef = useRef(false);
+  useEffect(() => {
+    if (!state.baselineData?.length || !state.comparisonData?.length) {
+      initialScrollDoneRef.current = false;
+      return;
+    }
+    if (initialScrollDoneRef.current) { return; }
+    initialScrollDoneRef.current = true;
+    const hash = window.location.hash.slice(1);
+    if (!hash) { return; }
+    if (hash === "compare-final-results") {
+      setActiveTab("final");
+    } else if (hash.startsWith("compare-endpoint-") || hash === "compare-overview-charts") {
+      setActiveTab("endpoint");
+    }
+    const timer = setTimeout(() => {
+      document.getElementById(hash)?.scrollIntoView({ behavior: "smooth" });
+    }, 100);
+    return () => clearTimeout(timer);
+  }, [state.baselineData, state.comparisonData]);
+
   // Extract unique HTTP methods from both datasets
   const availableMethods = useMemo(() => {
     const methods = new Set<string>();
@@ -1368,7 +1435,12 @@ export const TestResultsCompare: React.FC<TestResultsCompareProps> = React.memo(
 
       {filteredBaselineData && filteredComparisonData && (
         <>
-          <H1>Performance & Error Metrics Comparison</H1>
+          <div id="compare-overview-charts">
+            <SectionHeadingH1>
+              Performance &amp; Error Metrics Comparison
+              <a href="#compare-overview-charts" className="anchor-link" onClick={(e) => handleAnchorClick(e, "compare-overview-charts")}>#</a>
+            </SectionHeadingH1>
+          </div>
           <COMPARISONCHARTSGRID>
             <CHARTCOLUMN>
               <H2>{baselineLabel}</H2>
@@ -1421,6 +1493,12 @@ export const TestResultsCompare: React.FC<TestResultsCompareProps> = React.memo(
 
           {activeTab === "endpoint" && (
             <TABCONTENT>
+              <div id="compare-endpoint-comparison">
+                <SectionHeadingH2>
+                  Endpoint Comparison
+                  <a href="#compare-endpoint-comparison" className="anchor-link" onClick={(e) => handleAnchorClick(e, "compare-endpoint-comparison")}>#</a>
+                </SectionHeadingH2>
+              </div>
               <p style={{ textAlign: "center", color: "#999", marginBottom: "1em" }}>
                 Per-endpoint metrics comparison (green = improvement, red = regression)
               </p>
@@ -1508,7 +1586,7 @@ export const TestResultsCompare: React.FC<TestResultsCompareProps> = React.memo(
               );
             };
 
-            return matchedEndpoints.map(({ key, method, hostname, path, baselineData, comparisonData }) => {
+            return matchedEndpoints.map(({ key, method, hostname, path, baselineData, comparisonData }, endpointIndex) => {
               // Aggregate baseline data for this endpoint
               let baselineRTT = null;
               let baselineCallCount = 0;
@@ -1568,11 +1646,13 @@ export const TestResultsCompare: React.FC<TestResultsCompareProps> = React.memo(
                 comparisonRTT.free();
               }
 
+              const endpointAnchorId = compareEndpointAnchorId(endpointIndex);
               return (
-                <div key={key} style={{ marginBottom: "3em" }}>
-                  <H2 style={{ fontSize: "1.2em", marginBottom: "0.5em" }}>
+                <div key={key} id={endpointAnchorId} style={{ marginBottom: "3em" }}>
+                  <SectionHeadingH2 style={{ fontSize: "1.2em", marginBottom: "0.5em" }}>
                     {method} {hostname}{path}
-                  </H2>
+                    <a href={`#${endpointAnchorId}`} className="anchor-link" onClick={(e) => handleAnchorClick(e, endpointAnchorId)}>#</a>
+                  </SectionHeadingH2>
                   <TABLECONTAINER>
                     <DATATABLE>
                       <thead>
@@ -1605,6 +1685,12 @@ export const TestResultsCompare: React.FC<TestResultsCompareProps> = React.memo(
 
           {activeTab === "final" && (
             <TABCONTENT>
+              <div id="compare-final-results">
+                <SectionHeadingH2>
+                  Final Results Comparison
+                  <a href="#compare-final-results" className="anchor-link" onClick={(e) => handleAnchorClick(e, "compare-final-results")}>#</a>
+                </SectionHeadingH2>
+              </div>
               <COMPARISONCHARTSGRID>
                 <CHARTCOLUMN>
                   <H2>{baselineLabel}</H2>


### PR DESCRIPTION
## Summary

- Adds `#` anchor links to all major section headings in `TestResults` and `TestResultsCompare` (both controller and guide variants) so users can share URLs that scroll directly to a specific section
- Per-endpoint headings are individually addressable via `endpoint-{id}` fragments; `FinalResultsTable` rows include a `#` jump link back to the corresponding endpoint detail
- Tab sections in `TestResultsCompare` (`compare-endpoint-comparison`, `compare-final-results`) are hash-addressable — opening a URL with a compare hash auto-switches to the correct tab before scrolling

## Technical notes

- `history.replaceState` used instead of `window.location.hash` assignment to avoid firing `hashchange` events that framework routers could intercept
- A `useRef` one-shot guard prevents polling data refreshes from re-triggering the on-load scroll and causing unwanted double-scroll behavior
- `bucketAnchorId` and `compareEndpointAnchorId` helper functions added to `utils.ts` (controller and guide) with unit tests

## Test plan

- [ ] Open a TestResults page; hover over "Time Taken", "Overview Charts", "Performance & Error Metrics", "Final Results", "Endpoint Data" — `#` link appears on hover, clicking scrolls and updates URL hash
- [ ] Click the `#` link on an individual endpoint heading — URL updates to `#endpoint-{id}`, clicking the `#` in the FinalResultsTable row for that endpoint scrolls back up to it
- [ ] Copy a `#endpoint-{N}` URL and open it in a new tab — page scrolls to that endpoint on load
- [ ] Copy a `#compare-final-results` URL and open it — page loads on the "Final Results Comparison" tab and scrolls to the heading
- [ ] Copy a `#compare-endpoint-{N}` URL and open it — page loads on the "Endpoint Comparison" tab
- [ ] Verify no double-scroll occurs when clicking an anchor while the page is actively polling (wait a few seconds and confirm the view doesn't jump back)
- [ ] Run `npm test` (controller and guide) — all tests pass
- [ ] Run `npm run linterror` (controller and guide) — zero lint warnings