### PR TITLE
PERF-4204 PPaaS - Fix /teststatus route SSR bug and gate TestInfo downloads by auth

### DIFF
--- a/controller/acceptance/pages.spec.ts
+++ b/controller/acceptance/pages.spec.ts
@@ -11,6 +11,7 @@ import {
   PAGE_START_TEST,
   PAGE_START_TEST_FORMAT,
   PAGE_TEST_HISTORY,
+  PAGE_TEST_STATUS,
   PAGE_TEST_STATUS_FORMAT,
   PAGE_TEST_UPDATE,
   PAGE_TEST_UPDATE_FORMAT
@@ -96,7 +97,7 @@ describe("Web Page Acceptance Tests", () => {
       expect(html, `s3Folder '${s3Folder}' in results`).to.include(s3Folder);
     });
 
-    it("GET /test/[testId] should respond 200 with test data in the HTML", async () => {
+    it("GET /teststatus should respond 200 with test data in the HTML", async () => {
       const url = integrationUrl + PAGE_TEST_STATUS_FORMAT(testId);
       log(`GET ${url}`, LogLevel.DEBUG);
       const res: AxiosResponse = await fetchNoRedirects(url);
@@ -105,6 +106,28 @@ describe("Web Page Acceptance Tests", () => {
       assertNoPageError(html);
       expect(html, "h1: Check the Test Status").to.include("Check the Test Status");
       expect(html, `testId '${testId}' in page`).to.include(testId);
+    });
+
+    it("with ?testId= should redirect 307 to /teststatus with the testId", async () => {
+      const url = `${integrationUrl}${PAGE_TEST_HISTORY}?testId=${encodeURIComponent(testId)}`;
+      log(`GET ${url}`, LogLevel.DEBUG);
+      const res: AxiosResponse = await fetchNoRedirects(url);
+      expect(res.status, "status").to.equal(307);
+      expect(res.headers.location, "redirect location header").to.not.equal(undefined);
+      expect(res.headers.location, "redirect to /teststatus").to.include(PAGE_TEST_STATUS);
+      expect(res.headers.location, `redirect includes testId '${testId}'`).to.include(encodeURIComponent(testId));
+    });
+
+    it("with ?testId= and results and compare should redirect 307 preserving all params", async () => {
+      const url = `${integrationUrl}${PAGE_TEST_HISTORY}?testId=${encodeURIComponent(testId)}&results=0&compare=${encodeURIComponent(testId)}`;
+      log(`GET ${url}`, LogLevel.DEBUG);
+      const res: AxiosResponse = await fetchNoRedirects(url);
+      expect(res.status, "status").to.equal(307);
+      expect(res.headers.location, "redirect location header").to.not.equal(undefined);
+      expect(res.headers.location, "redirect to /teststatus").to.include(PAGE_TEST_STATUS);
+      expect(res.headers.location, "redirect includes testId").to.include(encodeURIComponent(testId));
+      expect(res.headers.location, "redirect includes results=0").to.include("results=0");
+      expect(res.headers.location, "redirect includes compare").to.include(`compare=${encodeURIComponent(testId)}`);
     });
   });
 

--- a/controller/acceptance/wdio/starttest.spec.ts
+++ b/controller/acceptance/wdio/starttest.spec.ts
@@ -2,7 +2,8 @@ import { LogLevel, log } from "@fs/ppaas-common";
 import {
   PAGE_CALENDAR,
   PAGE_START_TEST,
-  PAGE_START_TEST_FORMAT
+  PAGE_START_TEST_FORMAT,
+  PAGE_TEST_STATUS
 } from "../../types";
 import { assertNoPageError, getTestData } from "./util";
 import path from "path";
@@ -81,12 +82,12 @@ describe("Start Test Submissions", () => {
       // Should navigate to test history page on success
       await browser.waitUntil(async () => {
         const url = await browser.getUrl();
-        return /\/test\/\w/.test(url);
-      }, { timeout: 30000, timeoutMsg: "Expected navigation to /test/<testId>" });
+        return url.includes(PAGE_TEST_STATUS) && url.includes("testId=");
+      }, { timeout: 30000, timeoutMsg: "Expected navigation to /teststatus?testId=" });
       await assertNoPageError();
       const envUrl = await browser.getUrl();
-      const envMatch = envUrl.match(/\/test\/(\w+)/);
-      if (envMatch?.[1]) { recentTestId = envMatch[1]; }
+      const envMatch = envUrl.match(/[?&]testId=([^&]+)/);
+      if (envMatch?.[1]) { recentTestId = decodeURIComponent(envMatch[1]); }
       log("basicwithenv with env vars: test submitted successfully", LogLevel.INFO, { recentTestId });
     });
   });
@@ -143,8 +144,8 @@ describe("Start Test Submissions", () => {
       // Should navigate to test history page on success
       await browser.waitUntil(async () => {
         const url = await browser.getUrl();
-        return /\/test\/\w/.test(url);
-      }, { timeout: 30000, timeoutMsg: "Expected navigation to /test/<testId>" });
+        return url.includes(PAGE_TEST_STATUS) && url.includes("testId=");
+      }, { timeout: 30000, timeoutMsg: "Expected navigation to /teststatus?testId=" });
       await assertNoPageError();
       log("basicwithfiles with files: test submitted successfully", LogLevel.INFO);
     });
@@ -213,8 +214,8 @@ describe("Start Test Submissions", () => {
       // Should navigate to test history page on success
       await browser.waitUntil(async () => {
         const currentUrl = await browser.getUrl();
-        return /\/test\/\w/.test(currentUrl);
-      }, { timeout: 30000, timeoutMsg: "Expected navigation to test history with testId" });
+        return currentUrl.includes(PAGE_TEST_STATUS) && currentUrl.includes("testId=");
+      }, { timeout: 30000, timeoutMsg: "Expected navigation to /teststatus with testId" });
       await assertNoPageError();
       log("re-run test: test re-submitted successfully", LogLevel.INFO);
     });

--- a/controller/acceptance/wdio/teststatus.spec.ts
+++ b/controller/acceptance/wdio/teststatus.spec.ts
@@ -105,4 +105,52 @@ describe("GET /teststatus (Test Status Page)", () => {
       }, { timeout: 5000, timeoutMsg: "URL still contains results= after deselecting" });
     });
   });
+
+  describe("Download Test Files", () => {
+    it("should show the Download Test Files button when running as admin", async () => {
+      const url = PAGE_TEST_STATUS_FORMAT(testId);
+      log(`navigating to ${url}`, LogLevel.DEBUG);
+      await browser.url(url);
+      await assertNoPageError();
+      const downloadButton = $("[data-testid='download-files-button']");
+      await expect(downloadButton).toExist();
+    });
+
+    it("clicking Download Test Files should replace the button with download links", async () => {
+      const url = PAGE_TEST_STATUS_FORMAT(testId);
+      log(`navigating to ${url}`, LogLevel.DEBUG);
+      await browser.url(url);
+      await assertNoPageError();
+      await $("[data-testid='download-files-button']").click();
+      // Button is replaced by a file list once the API responds (at minimum the yaml file is always present)
+      await browser.waitUntil(async () => {
+        return !(await $("[data-testid='download-files-button']").isExisting());
+      }, { timeout: 15000, timeoutMsg: "Expected download-files-button to be replaced by file list" });
+      const links = await $$("[data-testid='download-file-link']");
+      expect(links.length).toBeGreaterThan(0);
+      log("download rendered file links", LogLevel.INFO, { count: links.length, testId });
+    });
+
+    it("download file links should resolve to a valid download endpoint", async () => {
+      const url = PAGE_TEST_STATUS_FORMAT(testId);
+      log(`navigating to ${url}`, LogLevel.DEBUG);
+      await browser.url(url);
+      await assertNoPageError();
+      await $("[data-testid='download-files-button']").click();
+      await browser.waitUntil(async () => {
+        return !(await $("[data-testid='download-files-button']").isExisting());
+      }, { timeout: 15000, timeoutMsg: "Expected download-files-button to be replaced by file list" });
+      const firstLink = await $("[data-testid='download-file-link']");
+      const href = await firstLink.getAttribute("href");
+      expect(href).not.toBeNull();
+      log("navigating to download file link", LogLevel.DEBUG, { href });
+      // Navigate directly to the href — clicking triggers a file download (Content-Disposition: attachment)
+      // which doesn't change the browser URL, so we use browser.url() for a reliable assertion.
+      await browser.url(href!);
+      const bodyText = await $("body").getText();
+      expect(bodyText).not.toContain("Application error");
+      expect(bodyText).not.toContain("Internal Server Error");
+      log("download file link resolved successfully", LogLevel.INFO, { href });
+    });
+  });
 });

--- a/controller/acceptance/wdio/teststatus.spec.ts
+++ b/controller/acceptance/wdio/teststatus.spec.ts
@@ -5,7 +5,7 @@ import {
 } from "../../types";
 import { assertNoPageError, getTestData, getTestDataWithResults } from "./util";
 
-describe("GET /test/[testId] (Test Status Page)", () => {
+describe("GET /teststatus (Test Status Page)", () => {
   let testId: string;
   let s3Folder: string;
 
@@ -69,7 +69,7 @@ describe("GET /test/[testId] (Test Status Page)", () => {
     });
 
     it("with ?results=0 should auto-select the first result and load it", async () => {
-      const url = `${PAGE_TEST_STATUS_FORMAT(testDataWithResults!.testId)}?results=0`;
+      const url = PAGE_TEST_STATUS_FORMAT({ testId: testDataWithResults!.testId, results: 0 });
       log(`navigating to ${url}`, LogLevel.DEBUG);
       await browser.url(url);
       await assertNoPageError();
@@ -91,7 +91,7 @@ describe("GET /test/[testId] (Test Status Page)", () => {
     });
 
     it("deselecting should remove results= from the URL", async () => {
-      const url = `${PAGE_TEST_STATUS_FORMAT(testDataWithResults!.testId)}?results=0`;
+      const url = PAGE_TEST_STATUS_FORMAT({ testId: testDataWithResults!.testId, results: 0 });
       await browser.url(url);
       await assertNoPageError();
       const resultsLoaded = await $("[data-testid='results-loaded']");

--- a/controller/components/TestInfo/index.tsx
+++ b/controller/components/TestInfo/index.tsx
@@ -235,11 +235,11 @@ The previous "Stop" will automatically send a "Kill" after a few minutes if pewp
                 <DivRight>Download Test Files</DivRight>
                 <ul>
                   {state.downloadFiles.map((downloadFile: string, index: number) =>
-                    <li key={"downloadFile" + index}><LinkButton href={API_DOWNLOAD_FORMAT(testData.testId, downloadFile)} theme={{ buttonFontSize: "1.2rem" } }>{downloadFile}</LinkButton></li>
+                    <li key={"downloadFile" + index}><LinkButton href={API_DOWNLOAD_FORMAT(testData.testId, downloadFile)} theme={{ buttonFontSize: "1.2rem" }} data-testid="download-file-link">{downloadFile}</LinkButton></li>
                   )}
                 </ul>
               </li>
-            : <li key={"downloadFiles"}><Button onClick={onDownload} theme={{...defaultButtonTheme, buttonFontSize: "1.2rem"}} >Download Test Files</Button></li>)}
+            : <li key={"downloadFiles"}><Button onClick={onDownload} theme={{...defaultButtonTheme, buttonFontSize: "1.2rem"}} data-testid="download-files-button">Download Test Files</Button></li>)}
           {testData.lastUpdated && <li key="lastUpdated" style={lastUpdatedStyle}>Last Updated: {new Date(testData.lastUpdated).toLocaleString()}</li>}
         </ul>
       </Div>

--- a/controller/components/TestInfo/index.tsx
+++ b/controller/components/TestInfo/index.tsx
@@ -5,6 +5,7 @@ import {
   API_SCHEDULE_FORMAT,
   API_STOP,
   API_STOP_FORMAT,
+  AuthPermission,
   PAGE_CALENDAR,
   PAGE_START_TEST_FORMAT,
   PAGE_TEST_UPDATE_FORMAT,
@@ -43,6 +44,7 @@ export interface TestInfoState {
 // What this returns or calls from the parents
 export interface TestInfoProps {
   testData: TestData;
+  authPermission?: AuthPermission;
 }
 
 interface TestInfoStorybookProps extends TestInfoProps {
@@ -58,7 +60,7 @@ interface TestInfoStorybookProps extends TestInfoProps {
   error?: any;
 }
 
-export const TestInfo = ({ testData, ...testInfoProps }: TestInfoStorybookProps) => {
+export const TestInfo = ({ testData, authPermission, ...testInfoProps }: TestInfoStorybookProps) => {
   let doubleClickCheck: boolean = false;
   // The default states coming in from props is only so we can storybook them.
   const defaultState: TestInfoState = {
@@ -208,7 +210,7 @@ The previous "Stop" will automatically send a "Kill" after a few minutes if pewp
           {testData.resultsFileLocation && testData.resultsFileLocation.map((resultsLocation: string, index: number) =>
             <li key={"resultsFileLocation" + index}><a href={resultsLocation} target="_blank">S3 Results Url{index > 0 ? ` ${index + 1}` : ""}</a></li>)}
           <li key="testStatus">Status: {testData.status === TestStatus.Created ? "Test Uploaded, Waiting for Agent" : testData.status}</li>
-          {state.downloadFiles && state.downloadFiles.length > 0
+          {(authPermission && authPermission >= AuthPermission.Admin) && (state.downloadFiles && state.downloadFiles.length > 0
             ? <li key={"downloadFiles"}>
                 <DivRight>Download Test Files</DivRight>
                 <ul>
@@ -217,7 +219,7 @@ The previous "Stop" will automatically send a "Kill" after a few minutes if pewp
                   )}
                 </ul>
               </li>
-            : <li key={"downloadFiles"}><Button onClick={onDownload} theme={{...defaultButtonTheme, buttonFontSize: "1.2rem"}} >Download Test Files</Button></li>}
+            : <li key={"downloadFiles"}><Button onClick={onDownload} theme={{...defaultButtonTheme, buttonFontSize: "1.2rem"}} >Download Test Files</Button></li>)}
           {testData.lastUpdated && <li key="lastUpdated" style={lastUpdatedStyle}>Last Updated: {new Date(testData.lastUpdated).toLocaleString()}</li>}
         </ul>
       </Div>

--- a/controller/components/TestInfo/index.tsx
+++ b/controller/components/TestInfo/index.tsx
@@ -45,6 +45,7 @@ export interface TestInfoState {
 export interface TestInfoProps {
   testData: TestData;
   authPermission?: AuthPermission;
+  userId?: string | null;
 }
 
 interface TestInfoStorybookProps extends TestInfoProps {
@@ -60,7 +61,17 @@ interface TestInfoStorybookProps extends TestInfoProps {
   error?: any;
 }
 
-export const TestInfo = ({ testData, authPermission, ...testInfoProps }: TestInfoStorybookProps) => {
+export const canDownloadTestFiles = (
+  authPermission: AuthPermission | undefined,
+  userId: string | null | undefined,
+  testDataUserId: string | undefined
+): boolean => {
+  if (!authPermission || authPermission < AuthPermission.ReadOnly) { return false; }
+  if (authPermission >= AuthPermission.Admin) { return true; }
+  return !!(testDataUserId && userId === testDataUserId);
+};
+
+export const TestInfo = ({ testData, authPermission, userId, ...testInfoProps }: TestInfoStorybookProps) => {
   let doubleClickCheck: boolean = false;
   // The default states coming in from props is only so we can storybook them.
   const defaultState: TestInfoState = {
@@ -210,7 +221,7 @@ The previous "Stop" will automatically send a "Kill" after a few minutes if pewp
           {testData.resultsFileLocation && testData.resultsFileLocation.map((resultsLocation: string, index: number) =>
             <li key={"resultsFileLocation" + index}><a href={resultsLocation} target="_blank">S3 Results Url{index > 0 ? ` ${index + 1}` : ""}</a></li>)}
           <li key="testStatus">Status: {testData.status === TestStatus.Created ? "Test Uploaded, Waiting for Agent" : testData.status}</li>
-          {(authPermission && authPermission >= AuthPermission.Admin) && (state.downloadFiles && state.downloadFiles.length > 0
+          {canDownloadTestFiles(authPermission, userId, testData.userId) && (state.downloadFiles && state.downloadFiles.length > 0
             ? <li key={"downloadFiles"}>
                 <DivRight>Download Test Files</DivRight>
                 <ul>

--- a/controller/components/TestInfo/index.tsx
+++ b/controller/components/TestInfo/index.tsx
@@ -61,6 +61,15 @@ interface TestInfoStorybookProps extends TestInfoProps {
   error?: any;
 }
 
+/** Determines if a user can download test files based on their permissions and ownership
+ * If the user is an admin, they can download any test files. If the user is a read-only user,
+ * they can only download their own test files. If the user is a regular user, they cannot
+ * download any test files and the download button is hidden.
+ * @param authPermission The user's authentication permission level.
+ * @param userId The ID of the user making the request.
+ * @param testDataUserId The ID of the user who owns the test data.
+ * @returns True if the user can download the test files, false otherwise.
+*/
 export const canDownloadTestFiles = (
   authPermission: AuthPermission | undefined,
   userId: string | null | undefined,

--- a/controller/components/TestInfo/test-info.spec.tsx
+++ b/controller/components/TestInfo/test-info.spec.tsx
@@ -7,10 +7,10 @@ vi.mock("axios", () => ({
 }));
 vi.mock("next/router", () => ({ useRouter: () => ({ push: vi.fn(), replace: vi.fn(), pathname: "/", query: {} }) }));
 
+import { AuthPermission, TestData } from "../../types";
+import TestInfo, { canDownloadTestFiles } from ".";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
-import { TestData } from "../../types";
-import TestInfo from ".";
 import { TestStatus } from "@fs/ppaas-common/dist/types";
 
 const baseTestData: TestData = {
@@ -206,11 +206,53 @@ describe("TestInfo Component", () => {
     });
 
     it("shows an error when the download button is clicked and the response is invalid", async () => {
-      render(<TestInfo testData={baseTestData} />);
+      render(<TestInfo testData={baseTestData} authPermission={AuthPermission.Admin} />);
       fireEvent.click(screen.getByText("Download Test Files"));
       await waitFor(() => {
         expect(screen.getByText(/Error:/)).toBeInTheDocument();
       });
+    });
+  });
+
+  describe("canDownloadTestFiles", () => {
+    it("returns false when authPermission is undefined", () => {
+      expect(canDownloadTestFiles(undefined, "user@example.com", "user@example.com")).toBe(false);
+    });
+
+    it("returns false when authPermission is Expired", () => {
+      expect(canDownloadTestFiles(AuthPermission.Expired, "user@example.com", "user@example.com")).toBe(false);
+    });
+
+    it("returns false when authPermission is NoAuth", () => {
+      expect(canDownloadTestFiles(AuthPermission.NoAuth, "user@example.com", "user@example.com")).toBe(false);
+    });
+
+    it("returns true for Admin regardless of userId match", () => {
+      expect(canDownloadTestFiles(AuthPermission.Admin, "other@example.com", "user@example.com")).toBe(true);
+    });
+
+    it("returns true for Admin when testDataUserId is undefined", () => {
+      expect(canDownloadTestFiles(AuthPermission.Admin, undefined, undefined)).toBe(true);
+    });
+
+    it("returns true for ReadOnly user when userId matches testDataUserId", () => {
+      expect(canDownloadTestFiles(AuthPermission.ReadOnly, "user@example.com", "user@example.com")).toBe(true);
+    });
+
+    it("returns true for User when userId matches testDataUserId", () => {
+      expect(canDownloadTestFiles(AuthPermission.User, "user@example.com", "user@example.com")).toBe(true);
+    });
+
+    it("returns false for ReadOnly user when userId does not match testDataUserId", () => {
+      expect(canDownloadTestFiles(AuthPermission.ReadOnly, "other@example.com", "user@example.com")).toBe(false);
+    });
+
+    it("returns false when testDataUserId is undefined and user is not Admin", () => {
+      expect(canDownloadTestFiles(AuthPermission.ReadOnly, "user@example.com", undefined)).toBe(false);
+    });
+
+    it("returns false when userId is undefined and user is not Admin", () => {
+      expect(canDownloadTestFiles(AuthPermission.ReadOnly, undefined, "user@example.com")).toBe(false);
     });
   });
 });

--- a/controller/pages/index.tsx
+++ b/controller/pages/index.tsx
@@ -5,6 +5,7 @@ import {
   AuthPermission,
   AuthPermissions,
   ErrorResponse,
+  PAGE_TEST_STATUS_FORMAT,
   TestData,
   TestListResponse
 } from "../types";
@@ -190,14 +191,14 @@ export const getServerSideProps: GetServerSideProps =
       };
     }
 
-    // Redirect old /?testId= links to the new /test/[testId] page
+    // Redirect old /?testId= links to the /teststatus page
     if (ctx.query?.testId && !Array.isArray(ctx.query.testId)) {
-      const testId = ctx.query.testId;
-      const params = new URLSearchParams();
-      if (typeof ctx.query.results === "string") { params.set("results", ctx.query.results); }
-      if (typeof ctx.query.compare === "string") { params.set("compare", ctx.query.compare); }
-      const queryStr = params.toString();
-      const destination = queryStr ? `/test/${testId}?${queryStr}` : `/test/${testId}`;
+      const resultsStr = typeof ctx.query.results === "string" ? ctx.query.results : "";
+      const destination = formatPageHref(PAGE_TEST_STATUS_FORMAT({
+        testId: ctx.query.testId,
+        results: /^\d+$/.test(resultsStr) ? parseInt(resultsStr, 10) : undefined,
+        compare: typeof ctx.query.compare === "string" ? ctx.query.compare : undefined
+      }));
       return { redirect: { destination, permanent: false } };
     }
 

--- a/controller/pages/teststatus.tsx
+++ b/controller/pages/teststatus.tsx
@@ -204,7 +204,7 @@ const TestStatusPage = ({
     body = <TestStatusSection>
       <TestStatusDiv>
         <TestStatusSection>
-          <TestInfo testData={testData} />
+          <TestInfo testData={testData} authPermission={authPermission} />
         </TestStatusSection>
         {(testData.errors || state.pewpewStdErrors) && <TestStatusSection>
           {testData.errors && <Warning>

--- a/controller/pages/teststatus.tsx
+++ b/controller/pages/teststatus.tsx
@@ -56,6 +56,7 @@ export interface TestStatusProps {
   testData: TestData | undefined;
   errorLoading: string | undefined;
   authPermission?: AuthPermission;
+  userId?: string | null;
   resultsIndex?: number;
   compareTestId?: string;
 }
@@ -71,6 +72,7 @@ const TestStatusPage = ({
   testData,
   errorLoading,
   authPermission,
+  userId,
   resultsIndex: propsResultsIndex,
   compareTestId: propsCompareTestId
 }: TestStatusProps) => {
@@ -204,7 +206,7 @@ const TestStatusPage = ({
     body = <TestStatusSection>
       <TestStatusDiv>
         <TestStatusSection>
-          <TestInfo testData={testData} authPermission={authPermission} />
+          <TestInfo testData={testData} authPermission={authPermission} userId={userId} />
         </TestStatusSection>
         {(testData.errors || state.pewpewStdErrors) && <TestStatusSection>
           {testData.errors && <Warning>
@@ -295,6 +297,7 @@ export const getServerSideProps: GetServerSideProps =
         testData,
         errorLoading: undefined,
         authPermission: authPermissions.authPermission,
+        userId: authPermissions.userId,
         resultsIndex: !isNaN(resultsParam) ? resultsParam : undefined,
         compareTestId: typeof ctx.query.compare === "string" ? ctx.query.compare : undefined
       }

--- a/controller/pages/teststatus.tsx
+++ b/controller/pages/teststatus.tsx
@@ -4,29 +4,30 @@ import {
   AuthPermission,
   AuthPermissions,
   ErrorResponse,
+  PAGE_TEST_STATUS,
   TestData,
   TestDataResponse,
   TestManagerResponse
-} from "../../types";
-import { Danger, Warning } from "../../components/Alert";
+} from "../types";
+import { Danger, Warning } from "../components/Alert";
 import {
   GetServerSideProps,
   GetServerSidePropsContext,
   GetServerSidePropsResult
 } from "next";
-import { LogLevel, log } from "../../src/log";
+import { LogLevel, log } from "../src/log";
 import { LogLevel as LogLevelServer, log as logServer } from "@fs/ppaas-common";
 import React, { JSX, useEffect, useState } from "react";
 import axios, { AxiosError, AxiosResponse } from "axios";
-import { formatError, formatPageHref } from "../../src/clientutil";
-import Div from "../../components/Div";
-import { H1 } from "../../components/Headers";
-import { Layout } from "../../components/Layout";
-import { TestInfo } from "../../components/TestInfo";
-import { TestManager } from "../../src/testmanager";
-import { TestResults } from "../../components/TestResults";
+import { formatError, formatPageHref } from "../src/clientutil";
+import Div from "../components/Div";
+import { H1 } from "../components/Headers";
+import { Layout } from "../components/Layout";
+import { TestInfo } from "../components/TestInfo";
+import { TestManager } from "../src/testmanager";
+import { TestResults } from "../components/TestResults";
 import { TestStatus } from "@fs/ppaas-common/dist/types";
-import { authPage } from "../../src/authserver";
+import { authPage } from "../src/authserver";
 import styled from "styled-components";
 import { useRouter } from "next/router";
 
@@ -84,9 +85,11 @@ const TestStatusPage = ({
   const router = useRouter();
 
   const updateQuery = (changes: Record<string, string | undefined>): void => {
-    const params = new URLSearchParams();
+    const testId = Array.isArray(router.query.testId) ? router.query.testId[0] : router.query.testId;
+    if (!testId) { return; }
+    const params = new URLSearchParams({ testId });
     for (const [k, v] of Object.entries(router.query)) {
-      if (k === "testId") { continue; } // path param, not a query string param
+      if (k === "testId") { continue; }
       if (Array.isArray(v)) {
         v.forEach((val) => params.append(k, val));
       } else if (v !== undefined) {
@@ -100,9 +103,7 @@ const TestStatusPage = ({
         params.delete(k);
       }
     }
-    const queryStr = params.toString();
-    const basePath = router.asPath.split("?")[0];
-    const newUrl = queryStr ? `${basePath}?${queryStr}` : basePath;
+    const newUrl = `${PAGE_TEST_STATUS}?${params.toString()}`;
     log("router.push in updateQuery", LogLevel.DEBUG, { newUrl, pathname: router.pathname, query: router.query, asPath: router.asPath });
     router.push(newUrl, formatPageHref(newUrl), { shallow: true }).catch((error: unknown) => log("router.push error", LogLevel.ERROR, error));
   };
@@ -276,7 +277,7 @@ export const getServerSideProps: GetServerSideProps =
       };
     }
 
-    const testId = ctx.params?.testId;
+    const testId = ctx.query?.testId;
     if (!testId || Array.isArray(testId)) {
       return { redirect: { destination: "/", permanent: false } };
     }

--- a/controller/types/pages.ts
+++ b/controller/types/pages.ts
@@ -3,7 +3,22 @@ import type { Route } from "next";
 export const PAGE_START_TEST: Route = "/test";
 export const PAGE_START_TEST_FORMAT = (testId: string, edit?: boolean): Route => `${PAGE_START_TEST}?testId=${testId}${edit ? "&edit" : ""}` as Route;
 export const PAGE_TEST_HISTORY: Route = "/";
-export const PAGE_TEST_STATUS_FORMAT = (testId: string): Route => `/test/${testId}` as Route;
+export const PAGE_TEST_STATUS: Route = "/teststatus";
+export interface TestStatusParams {
+  testId: string;
+  results?: number;
+  compare?: string;
+}
+export const PAGE_TEST_STATUS_FORMAT = (params: string | TestStatusParams): Route => {
+  if (typeof params === "string") {
+    return `${PAGE_TEST_STATUS}?testId=${params}` as Route;
+  }
+  const { testId, results, compare } = params;
+  const searchParams = new URLSearchParams({ testId });
+  if (results !== undefined) { searchParams.set("results", String(results)); }
+  if (compare !== undefined) { searchParams.set("compare", compare); }
+  return `${PAGE_TEST_STATUS}?${searchParams.toString()}` as Route;
+};
 export const PAGE_TEST_UPDATE: Route = "/testupdate";
 export const PAGE_TEST_UPDATE_FORMAT = (testId: string): Route => `${PAGE_TEST_UPDATE}?testId=${testId}` as Route;
 export const PAGE_CALENDAR: Route = "/calendar";


### PR DESCRIPTION
## Summary

Fixes two bugs introduced in PR #384: the `/test/[testId]` dynamic route forced full SSR on every navigation (breaking SPA client-side routing), and the `TestInfo` download button was visible to all authenticated users despite test files potentially containing passwords. Converts the route to `/teststatus?testId=`, adds a `canDownloadTestFiles` guard for admins and test owners, and threads auth props through from the page to the component.

## Reasoned Changes

### Route restructuring: dynamic segment → query-parameter page
**What:** \`pages/test/[testId].tsx\` is renamed to \`pages/teststatus.tsx\` and the test ID is moved from a path segment to a \`?testId=\` query parameter.
**Why:** Next.js always triggers a full SSR round-trip when navigating to a dynamic-segment route, breaking SPA client-side navigation between test status pages. The query-parameter design avoids the dynamic segment entirely, restoring shallow \`router.push\` navigation. The trade-off is that any external links using the old \`/test/<testId>\` form silently break, which was accepted because the dynamic route was introduced only in PR #384 with no established external link surface.

### \`PAGE_TEST_STATUS\` constant and overloaded \`PAGE_TEST_STATUS_FORMAT\`
**What:** A new \`PAGE_TEST_STATUS\` route constant is added and \`PAGE_TEST_STATUS_FORMAT\` is rewritten to accept either a plain \`string\` (backward-compat) or a typed \`TestStatusParams\` object carrying \`testId\`, optional \`results\`, and optional \`compare\`.
**Why:** Callers that previously appended query strings manually needed a typed, centralized builder to avoid drift. Accepting \`string | TestStatusParams\` preserves backward compatibility with every existing call site without a sweeping refactor. The overload also lets \`index.tsx\`'s redirect and \`updateQuery\` share the same constant, making all URL construction proxy-safe.

### \`updateQuery\` rewrite using \`PAGE_TEST_STATUS\` constant
**What:** The \`updateQuery\` function in \`teststatus.tsx\` builds the new URL from the \`PAGE_TEST_STATUS\` constant rather than by splitting \`router.asPath\` on \`?\`.
**Why:** \`router.asPath\` under a reverse proxy includes the base path prefix, so splitting on \`?\` produced double-prefixed URLs. The new implementation seeds \`URLSearchParams\` with \`testId\` directly and appends or deletes other params, removing all dependency on the string form of the current path. The function returns early if \`testId\` is absent, preventing a silent empty-URL push.

### Download gating: \`canDownloadTestFiles\` and prop threading
**What:** A new exported pure function \`canDownloadTestFiles(authPermission, userId, testDataUserId)\` gates the download button in \`TestInfo\`, and \`authPermission\` + \`userId\` are threaded from \`getServerSideProps\` through \`TestStatusProps\` to \`TestInfo\`. JSDoc documents the permission logic inline.
**Why:** Downloaded test files may contain passwords, so the download button must not be visible to arbitrary authenticated users. Admins are unconditionally allowed; non-admins are allowed only when \`testData.userId\` is set and matches the logged-in \`userId\`; when \`testData.userId\` is absent, only admins can download. Extracting the logic into a named pure function makes it independently testable and keeps the JSX condition readable.

### \`data-testid\` attributes on download elements
**What:** \`data-testid="download-files-button"\` is added to the initial download button and \`data-testid="download-file-link"\` is added to each rendered file link in \`TestInfo\`.
**Why:** Text-based wdio selectors (e.g. \`button=Download Test Files\`) break when labels change and are ambiguous when the same text appears elsewhere. \`data-testid\` attributes follow the existing convention used throughout the wdio test suite (\`submit-test-button\`, \`results-select\`, etc.) and are stable regardless of copy changes. \`LinkButton\` already had \`data-testid\` wired through to the underlying \`<a>\` tag; \`Button\` (a \`styled.button\`) accepts it natively.

### Test coverage: unit tests, acceptance tests, and wdio browser tests
**What:** Ten unit test cases covering all branches of \`canDownloadTestFiles\` are added, the broken download-button interaction test is fixed, acceptance redirect tests are updated, and three wdio browser tests verify the download flow end-to-end.
**Why:** The gating function has enough branching (undefined, Expired, NoAuth, ReadOnly/User matching vs. non-matching, Admin) that exhaustive coverage is warranted. The wdio tests cover what unit tests cannot: that the download button is visible in admin mode, that clicking it replaces the button with a real file list from S3, and that those file links resolve to a valid download endpoint. The acceptance tests run with auth disabled (effectively admin), so all three browser tests are expected to pass unconditionally.

## Risk Assessment

Risk concentrates in \`updateQuery\`'s early-return on missing \`testId\` and the \`canDownloadTestFiles\` asymmetry where \`ReadOnly\` users who own a test can download while those who don't cannot.

### Highest-Risk Areas
1. **\`controller/pages/teststatus.tsx:90\`** — \`updateQuery\` silently no-ops when \`router.query.testId\` is undefined (hydration window before Next.js populates the query); any \`updateQuery\` call during that window drops navigation without feedback, potentially diverging \`resultsIndex\` state from the URL.
2. **\`controller/components/TestInfo/index.tsx:221-232\`** — When \`authPermission\` is \`undefined\`, the entire download section (including already-fetched file links) is hidden with no feedback; this is the expected behavior but should be confirmed in Storybook or with a test that renders without the prop.
3. **\`controller/pages/index.tsx:194-202\`** — \`formatPageHref(PAGE_TEST_STATUS_FORMAT({...}))\` double-applies the base-path prefix if \`formatPageHref\` is not idempotent in server context; mitigated by \`formatPageHref\`'s \`startsWith(basePath)\` guard, but worth confirming under the proxy.

## Review Hotspots

1. **\`controller/components/TestInfo/index.tsx:221-232\`** — The ternary that wraps \`canDownloadTestFiles(...)\` around the existing inner ternary was adjusted across two commits; the closing-paren placement is non-obvious and worth a careful read.
2. **\`controller/pages/teststatus.tsx:87-113\`** — \`updateQuery\` seeds \`testId\` explicitly then skips it when iterating \`router.query\` — reviewers should confirm \`testId\` cannot appear twice in the final \`URLSearchParams\`.

## Testing

- **Build**: \`npm run build\` clean; \`/teststatus\` in route list, \`/test/[testId]\` absent.
- **Lint**: \`npm run linterror\` zero warnings.
- **Unit tests**: 403/403 passing (29 test files). 10 new \`canDownloadTestFiles\` cases; fixed download-button interaction test now requires \`authPermission={AuthPermission.Admin}\`.
- **New acceptance tests**: Two \`/?testId=\` redirect cases in \`pages.spec.ts\` (single-param and full-param with results+compare).
- **Updated WDIO tests**: \`starttest.spec.ts\` URL assertions use \`PAGE_TEST_STATUS\`; \`teststatus.spec.ts\` uses object form of \`PAGE_TEST_STATUS_FORMAT\`.
- **New WDIO tests**: Three browser tests in \`teststatus.spec.ts\` — download button visible (admin mode), clicking it replaces the button with file links, and navigating to a file link resolves without error.
- **Gaps**: \`updateQuery\` hydration-window behavior has no automated test. Download section hidden-when-no-auth has no automated test.

## Checklist

- [x] Code follows project style guidelines (lint clean, TypeScript strict)
- [x] Tests added/updated and passing
- [x] Documentation updated if needed
- [x] No breaking changes (old \`/?testId=\` URLs redirect; all \`PAGE_TEST_STATUS_FORMAT\` string callers unaffected)
- [x] Reviewed my own code for obvious issues