### PR TITLE
PERF-4320 PPaaS — Log stop/kill/updateYaml userId in test activity log

### DIFF
--- a/agent/createtest/pewpewtest.spec.ts
+++ b/agent/createtest/pewpewtest.spec.ts
@@ -17,6 +17,7 @@ import {
   TestMessage,
   TestStatus,
   TestStatusMessage,
+  UpdateYamlMessageData,
   log,
   logger,
   ppaass3message,
@@ -292,6 +293,9 @@ describe("PewPewTest Create Test", () => {
         expect(testStatus.errors, "errors should be set").to.not.equal(undefined);
         expect(testStatus.errors, "errors should not be empty").to.have.length.greaterThan(0);
         expect(JSON.stringify(testStatus.errors), "error message").to.include("Ctrl-C");
+        expect(testStatus.changelogs, "changelogs should be set").to.not.equal(undefined);
+        expect(testStatus.changelogs, "changelogs should not be empty").to.have.length.greaterThan(0);
+        expect(JSON.stringify(testStatus.changelogs), "changelog message").to.include("StopTest");
         done();
       })
       .catch((error) => {
@@ -333,6 +337,10 @@ describe("PewPewTest Create Test", () => {
             expect(`${error}`, "test.launch() error").to.include("pewpew exited with code null and signal SIGKILL");
             expect(test!.getResultsFile(), "resultsFile").to.not.equal(undefined);
             expect(Date.now() - startTime, "Actual Run Time").to.be.lessThan(120000);
+            const killTestStatus = test!.getTestStatusMessage();
+            expect(killTestStatus.changelogs, "changelogs should be set").to.not.equal(undefined);
+            expect(killTestStatus.changelogs, "changelogs should not be empty").to.have.length.greaterThan(0);
+            expect(JSON.stringify(killTestStatus.changelogs), "changelog message").to.include("KillTest");
             done();
           } catch (error2) {
             log ("'Retrieve Test and launch, then kill should succeed' error in catch", LogLevel.ERROR, error2);
@@ -368,7 +376,7 @@ describe("PewPewTest Create Test", () => {
           const updateMessage = new PpaasS3Message({
             testId: ppaasTestId!,
             messageType: MessageType.UpdateYaml,
-            messageData: createTestFilename
+            messageData: { filename: createTestFilename } as UpdateYamlMessageData
           });
           // .msg
           const s3MessageKey = s3.KEYSPACE_PREFIX + getKeyS3Message(ppaasTestId!);
@@ -381,6 +389,10 @@ describe("PewPewTest Create Test", () => {
         await test!.launch();
         expect(test!.getResultsFile()).to.not.equal(undefined);
         expect(Date.now() - startTime, "Actual Run Time").to.be.lessThan(120000);
+        const updateTestStatus = test!.getTestStatusMessage();
+        expect(updateTestStatus.changelogs, "changelogs should be set").to.not.equal(undefined);
+        expect(updateTestStatus.changelogs, "changelogs should not be empty").to.have.length.greaterThan(0);
+        expect(JSON.stringify(updateTestStatus.changelogs), "changelog message").to.include("UpdateYaml");
         done();
       })
       .catch((error) => {
@@ -763,7 +775,7 @@ describe("PewPewTest Create Test", () => {
           const updateMessage = new PpaasS3Message({
             testId: ppaasTestId!,
             messageType: MessageType.UpdateYaml,
-            messageData: createTestFilename
+            messageData: { filename: createTestFilename } as UpdateYamlMessageData
           });
           // .msg
           const s3MessageKey = s3.KEYSPACE_PREFIX + getKeyS3Message(ppaasTestId!);

--- a/agent/createtest/pewpewtest.spec.ts
+++ b/agent/createtest/pewpewtest.spec.ts
@@ -148,7 +148,8 @@ describe("PewPewTest Create Test", () => {
         errors: [],
         version: "bogus",
         queueName: "bogus",
-        userId: "unittestuser"
+        userId: "unittestuser",
+        changelogs: []
       };
       (expectedTestStatusMessage as TestStatusMessage).errors = undefined; // Set it back to empty so it can get cleared out
 

--- a/agent/integration/pewpewtest.spec.ts
+++ b/agent/integration/pewpewtest.spec.ts
@@ -9,9 +9,11 @@ import {
   PpaasTestMessage,
   PpaasTestStatus,
   SqsQueueType,
+  StopKillMessageData,
   TestMessage,
   TestStatus,
   TestStatusMessage,
+  UpdateYamlMessageData,
   log,
   logger,
   s3,
@@ -234,11 +236,12 @@ describe("PewPewTest Integration Test", () => {
         log("Test retrieved: " + test!.getYamlFile(), LogLevel.DEBUG);
 
         // Wait 65 seconds (at least one bucket) then send a stop message
+        const stopMessageData: StopKillMessageData = { userId: "stoptest@integration.test" };
         setTimeout(() => {
           const stopMessage = new PpaasS3Message({
             testId: ppaasTestId!,
             messageType: MessageType.StopTest,
-            messageData: undefined
+            messageData: stopMessageData
           });
           stopMessage.send()
           .then((messageId: string | undefined) => log("Stop Test MessageId: " + messageId, LogLevel.DEBUG))
@@ -249,6 +252,11 @@ describe("PewPewTest Integration Test", () => {
         await test!.launch();
         expect(test!.getResultsFile()).to.not.equal(undefined);
         expect(Date.now() - startTime, "Actual Run Time").to.be.lessThan(120000);
+        const stopTestStatus = test!.getTestStatusMessage();
+        expect(stopTestStatus.changelogs, "changelogs should be set").to.not.equal(undefined);
+        expect(stopTestStatus.changelogs, "changelogs should not be empty").to.have.length.greaterThan(0);
+        expect(JSON.stringify(stopTestStatus.changelogs), "changelog message").to.include("StopTest");
+        expect(JSON.stringify(stopTestStatus.changelogs), "changelog userId").to.include(stopMessageData.userId!);
         // Validate S3
         const filename: string = basename(test!.getResultsFile()!);
         const result = await s3.getObject(`${ppaasTestId!.s3Folder}/${filename}`);
@@ -269,6 +277,7 @@ describe("PewPewTest Integration Test", () => {
         expect(test!.getYamlFile()).to.not.equal(undefined);
         expect(test!.getResultsFile()).to.equal(undefined);
         log("Test retrieved: " + test!.getYamlFile(), LogLevel.DEBUG);
+        const updateMessageData: UpdateYamlMessageData = { filename: createTestFilename, userId: "updateyaml@integration.test" };
         // Wait 65 seconds (at least one bucket) then update shorter
         setTimeout(async () => {
           s3File = new PpaasS3File({
@@ -281,7 +290,7 @@ describe("PewPewTest Integration Test", () => {
           const updateMessage = new PpaasS3Message({
             testId: ppaasTestId!,
             messageType: MessageType.UpdateYaml,
-            messageData: createTestFilename
+            messageData: updateMessageData
           });
           updateMessage.send()
           .then((messageId: string | undefined) => log("Update Yaml MessageId: " + messageId, LogLevel.DEBUG))
@@ -292,6 +301,11 @@ describe("PewPewTest Integration Test", () => {
         await test!.launch();
         expect(test!.getResultsFile()).to.not.equal(undefined);
         expect(Date.now() - startTime, "Actual Run Time").to.be.lessThan(120000);
+        const updateTestStatus = test!.getTestStatusMessage();
+        expect(updateTestStatus.changelogs, "changelogs should be set").to.not.equal(undefined);
+        expect(updateTestStatus.changelogs, "changelogs should not be empty").to.have.length.greaterThan(0);
+        expect(JSON.stringify(updateTestStatus.changelogs), "changelog message").to.include("UpdateYaml");
+        expect(JSON.stringify(updateTestStatus.changelogs), "changelog userId").to.include(updateMessageData.userId!);
         // Validate S3
         const filename: string = basename(test!.getResultsFile()!);
         const result = await s3.getObject(`${ppaasTestId!.s3Folder}/${filename}`);

--- a/agent/integration/pewpewtest.spec.ts
+++ b/agent/integration/pewpewtest.spec.ts
@@ -78,7 +78,8 @@ describe("PewPewTest Integration Test", () => {
       errors: [],
       version: "bogus",
       queueName: "bogus",
-      userId: "unittestuser"
+      userId: "unittestuser",
+      changelogs: []
     };
     (expectedTestStatusMessage as TestStatusMessage).errors = undefined; // Set it back to empty so it can get cleared out
     try {

--- a/agent/src/pewpewtest.ts
+++ b/agent/src/pewpewtest.ts
@@ -8,9 +8,11 @@ import {
   PpaasTestId,
   PpaasTestMessage,
   PpaasTestStatus,
+  StopKillMessageData,
   TestMessage,
   TestStatus,
   TestStatusMessage,
+  UpdateYamlMessageData,
   YamlParser,
   ec2,
   log,
@@ -709,9 +711,10 @@ export class PewPewTest {
    * @param killTest {boolean} Optional: If true, a SIGKILL is immediately sent rather than a SIGINT
    * @returns {Promise<void>}
    */
-  public stop (killTest?: boolean): Promise<void> {
+  public stop (killTest?: boolean, userId?: string): Promise<void> {
     this.stopCalled = true;
-    this.ppaasTestStatus.errors = [...(this.ppaasTestStatus.errors || []), `Received ${killTest ? "KillTest" : "StopTest"} message from controller`];
+    const changelogEntry = `Received ${killTest ? "KillTest" : "StopTest"} message from controller${userId ? ` by ${userId}` : ""}`;
+    this.ppaasTestStatus.changelogs = [...(this.ppaasTestStatus.changelogs || []), changelogEntry];
     return killTest ? this.internalKill() : this.internalStop();
   }
 
@@ -941,19 +944,24 @@ export class PewPewTest {
           // Process message and start a test
           try {
             switch (messageToHandle.messageType) {
-              case MessageType.StopTest:
-                this.log(`Received ${messageToHandle.messageType} for ${this.testMessage.testId}. Stopping test.`, LogLevel.INFO);
+              case MessageType.StopTest: {
+                const stopData = messageToHandle.messageData as StopKillMessageData | undefined;
+                this.log(`Received ${messageToHandle.messageType} for ${this.testMessage.testId}. Stopping test.`, LogLevel.INFO, { userId: stopData?.userId });
                 // Call the external, not internal stop
-                this.stop().catch(() => { /* logs automatically */ });
+                this.stop(false, stopData?.userId).catch(() => { /* logs automatically */ });
                 this.log(`handleMessage Complete ${messageToHandle.messageType}`, LogLevel.DEBUG, messageToHandle);
                 break;
-                case MessageType.KillTest:
-                  this.log(`Received ${messageToHandle.messageType} for ${this.testMessage.testId}. Killing test.`, LogLevel.WARN);
-                  this.stop(true).catch(() => { /* logs automatically */ });
-                  this.log(`handleMessage Complete ${messageToHandle.messageType}`, LogLevel.DEBUG, messageToHandle);
+              }
+              case MessageType.KillTest: {
+                const killData = messageToHandle.messageData as StopKillMessageData | undefined;
+                this.log(`Received ${messageToHandle.messageType} for ${this.testMessage.testId}. Killing test.`, LogLevel.WARN, { userId: killData?.userId });
+                this.stop(true, killData?.userId).catch(() => { /* logs automatically */ });
+                this.log(`handleMessage Complete ${messageToHandle.messageType}`, LogLevel.DEBUG, messageToHandle);
                 break;
-              case MessageType.UpdateYaml:
-                this.log(`Received ${messageToHandle.messageType} for ${this.testMessage.testId}. Updating Yaml.`, LogLevel.INFO);
+              }
+              case MessageType.UpdateYaml: {
+                const updateData = messageToHandle.messageData as UpdateYamlMessageData | undefined;
+                this.log(`Received ${messageToHandle.messageType} for ${this.testMessage.testId}. Updating Yaml.`, LogLevel.INFO, { userId: updateData?.userId });
                 // Download the new file
                 await this.yamlS3File.download();
                 // Check and edit the new run time
@@ -969,7 +977,6 @@ export class PewPewTest {
                       this.log(`${messageToHandle.messageType}: ${this.getYamlFile()} new testRunTimeMn ${newRuntime}. Updating.`, LogLevel.INFO,
                         { testRunTimeMn: this.testMessage.testRunTimeMn, startTime: this.startTime.getTime(), testEnd: this.testEnd });
                       this.ppaasTestStatus.endTime = this.testEnd;
-                      await this.writeTestStatus();
                     }
                   } catch (error) {
                     const message: string = `Could not parse new yaml file ${this.getYamlFile()}`;
@@ -983,8 +990,12 @@ export class PewPewTest {
                     errorMessage.send().catch((sendError) => this.log("Could not send error communications message to controller", LogLevel.WARN, sendError));
                   }
                 }
+                const updateChangelogEntry = `UpdateYaml received${updateData?.userId ? ` from ${updateData.userId}` : ""} at ${new Date().toISOString()}`;
+                this.ppaasTestStatus.changelogs = [...(this.ppaasTestStatus.changelogs || []), updateChangelogEntry];
+                await this.writeTestStatus();
                 this.log(`handleMessage Complete ${messageToHandle.messageType}`, LogLevel.DEBUG, messageToHandle);
                 break;
+              }
               default:
                 this.log(`The agent cannot handle messages of this type at this time. Removing from queue: ${messageToHandle.messageType}`, LogLevel.WARN, messageToHandle.sanitizedCopy());
                 break;

--- a/agent/src/pewpewtest.ts
+++ b/agent/src/pewpewtest.ts
@@ -711,10 +711,11 @@ export class PewPewTest {
    * @param killTest {boolean} Optional: If true, a SIGKILL is immediately sent rather than a SIGINT
    * @returns {Promise<void>}
    */
-  public stop (killTest?: boolean, userId?: string): Promise<void> {
+  public async stop (killTest?: boolean, userId?: string): Promise<void> {
     this.stopCalled = true;
     const changelogEntry = `Received ${killTest ? "KillTest" : "StopTest"} message from controller${userId ? ` by ${userId}` : ""}`;
     this.ppaasTestStatus.changelogs = [...(this.ppaasTestStatus.changelogs || []), changelogEntry];
+    await this.writeTestStatus();
     return killTest ? this.internalKill() : this.internalStop();
   }
 

--- a/agent/src/server.ts
+++ b/agent/src/server.ts
@@ -51,7 +51,7 @@ export function start (): Application {
           }
           const yamlFile = config.testToRun.getYamlFile();
           const resultsUrl = config.testToRun.getResultsFileS3();
-          await config.testToRun.stop();
+          await config.testToRun.stop(false, "agent /stop api");
           res.status(200).json({ message: "Stop Test successfully called", testId, yamlFile, resultsUrl });
         } else {
           res.status(400).json({ message: "No test currently running" });

--- a/agent/test/pewpewtest.spec.ts
+++ b/agent/test/pewpewtest.spec.ts
@@ -67,6 +67,7 @@ class PewPewTestPublicCleanup extends PewPewTest {
   public cleanup (splunkForwarderExtraTime?: number): Promise<void> {
     return super.cleanup(splunkForwarderExtraTime);
   }
+  public get testStatus (): PpaasTestStatus { return this.ppaasTestStatus; }
 }
 
 describe("PewPewTest", () => {
@@ -204,6 +205,53 @@ describe("PewPewTest", () => {
     });
   });
 
+  describe("stop", () => {
+    const ppaasTestId: PpaasTestId = PpaasTestId.makeTestId(BASIC_TEST_FILENAME);
+    let testMessage: PpaasTestMessage;
+
+    before(() => {
+      testMessage = new PpaasTestMessage({
+        testId: ppaasTestId.testId,
+        s3Folder: ppaasTestId.s3Folder,
+        yamlFile: BASIC_TEST_FILENAME,
+        testRunTimeMn: 1,
+        version: PEWPEW_VERSION_LATEST,
+        envVariables: {},
+        restartOnFailure: false,
+        additionalFiles: [],
+        bucketSizeMs: 60000,
+        bypassParser: false
+      });
+    });
+
+    it("stop() without userId should add a StopTest changelog entry", () => {
+      const test = new PewPewTestPublicCleanup(testMessage);
+      test.stop(false).catch(() => { /* no process running */ });
+      expect(test.testStatus.changelogs, "changelogs").to.not.equal(undefined);
+      expect(test.testStatus.changelogs!.length, "changelogs.length").to.equal(1);
+      expect(test.testStatus.changelogs![0], "changelogs[0]").to.include("StopTest");
+      expect(test.testStatus.changelogs![0], "changelogs[0] no userId").to.not.include(" by ");
+    });
+
+    it("stop() with userId should include userId in StopTest changelog entry", () => {
+      const test = new PewPewTestPublicCleanup(testMessage);
+      test.stop(false, "stopuser@example.com").catch(() => { /* no process running */ });
+      expect(test.testStatus.changelogs, "changelogs").to.not.equal(undefined);
+      expect(test.testStatus.changelogs!.length, "changelogs.length").to.equal(1);
+      expect(test.testStatus.changelogs![0], "changelogs[0]").to.include("StopTest");
+      expect(test.testStatus.changelogs![0], "changelogs[0] userId").to.include("stopuser@example.com");
+    });
+
+    it("stop(true) with userId should add a KillTest changelog entry", () => {
+      const test = new PewPewTestPublicCleanup(testMessage);
+      test.stop(true, "killuser@example.com").catch(() => { /* no process running */ });
+      expect(test.testStatus.changelogs, "changelogs").to.not.equal(undefined);
+      expect(test.testStatus.changelogs!.length, "changelogs.length").to.equal(1);
+      expect(test.testStatus.changelogs![0], "changelogs[0]").to.include("KillTest");
+      expect(test.testStatus.changelogs![0], "changelogs[0] userId").to.include("killuser@example.com");
+    });
+  });
+
   describe("copyTestStatus", () => {
     const ppaasTestId: PpaasTestId = PpaasTestId.makeTestId(BASIC_TEST_FILENAME);
     const now = Date.now();
@@ -265,6 +313,7 @@ describe("PewPewTest", () => {
         expect(ppaasTestStatus.version, "version").to.equal(expectedTestStatusMessage.version);
         expect(ppaasTestStatus.queueName, "queueName").to.equal(expectedTestStatusMessage.queueName);
         expect(ppaasTestStatus.userId, "userId").to.equal(expectedTestStatusMessage.userId);
+        expect(JSON.stringify(ppaasTestStatus.changelogs), "changelogs").to.equal(JSON.stringify(expectedTestStatusMessage.changelogs));
         done();
       } catch (error) {
         done(error);
@@ -286,6 +335,7 @@ describe("PewPewTest", () => {
         expect(ppaasTestStatus.version, "version").to.equal(expectedTestStatusMessage.version);
         expect(ppaasTestStatus.queueName, "queueName").to.equal(expectedTestStatusMessage.queueName);
         expect(ppaasTestStatus.userId, "userId").to.equal(expectedTestStatusMessage.userId);
+        expect(JSON.stringify(ppaasTestStatus.changelogs), "changelogs").to.equal(JSON.stringify(expectedTestStatusMessage.changelogs));
         done();
       } catch (error) {
         done(error);
@@ -307,6 +357,7 @@ describe("PewPewTest", () => {
         expect(ppaasTestStatus.version, "version").to.equal(expectedTestStatusMessage.version);
         expect(ppaasTestStatus.queueName, "queueName").to.equal(expectedTestStatusMessage.queueName);
         expect(ppaasTestStatus.userId, "userId").to.equal(expectedTestStatusMessage.userId);
+        expect(JSON.stringify(ppaasTestStatus.changelogs), "changelogs").to.equal(JSON.stringify(expectedTestStatusMessage.changelogs));
         done();
       } catch (error) {
         done(error);
@@ -328,6 +379,7 @@ describe("PewPewTest", () => {
         expect(ppaasTestStatus.version, "version").to.equal(expectedTestStatusMessage.version);
         expect(ppaasTestStatus.queueName, "queueName").to.equal(expectedTestStatusMessage.queueName);
         expect(ppaasTestStatus.userId, "userId").to.equal(expectedTestStatusMessage.userId);
+        expect(JSON.stringify(ppaasTestStatus.changelogs), "changelogs").to.equal(JSON.stringify(expectedTestStatusMessage.changelogs));
         done();
       } catch (error) {
         done(error);
@@ -349,6 +401,7 @@ describe("PewPewTest", () => {
         expect(ppaasTestStatus.version, "version").to.equal(expectedTestStatusMessage.version);
         expect(ppaasTestStatus.queueName, "queueName").to.equal(expectedTestStatusMessage.queueName);
         expect(ppaasTestStatus.userId, "userId").to.equal(expectedTestStatusMessage.userId);
+        expect(JSON.stringify(ppaasTestStatus.changelogs), "changelogs").to.equal(JSON.stringify(expectedTestStatusMessage.changelogs));
         done();
       } catch (error) {
         done(error);
@@ -370,6 +423,7 @@ describe("PewPewTest", () => {
         expect(ppaasTestStatus.version, "version").to.equal(expectedTestStatusMessage.version);
         expect(ppaasTestStatus.queueName, "queueName").to.equal(expectedTestStatusMessage.queueName);
         expect(ppaasTestStatus.userId, "userId").to.equal(expectedTestStatusMessage.userId);
+        expect(JSON.stringify(ppaasTestStatus.changelogs), "changelogs").to.equal(JSON.stringify(expectedTestStatusMessage.changelogs));
         done();
       } catch (error) {
         done(error);

--- a/agent/test/pewpewtest.spec.ts
+++ b/agent/test/pewpewtest.spec.ts
@@ -224,7 +224,8 @@ describe("PewPewTest", () => {
       errors: ["error1"],
       version: "version1",
       queueName: "queue1",
-      userId: "user1"
+      userId: "user1",
+      changelogs: ["changelog1"]
     };
     const fullTestStatusMessageChanged: Required<TestStatusMessage> = {
       startTime: now + 5,
@@ -237,7 +238,8 @@ describe("PewPewTest", () => {
       errors: ["error2", "error3"],
       version: "version2",
       queueName: "queue2",
-      userId: "user2"
+      userId: "user2",
+      changelogs: ["changelog2", "changelog3"]
     };
     const extendedTestStatusMessage: TestStatusMessage = {
       startTime: now + 1,
@@ -404,7 +406,8 @@ describe("PewPewTest", () => {
         errors: [],
         version: "bogus",
         queueName: "bogus",
-        userId: "unittestuser"
+        userId: "unittestuser",
+        changelogs: []
       };
       (expectedTestStatusMessage as TestStatusMessage).errors = undefined; // Set it back to empty so it can get cleared out
       try {

--- a/common/integration/ppaasteststatus.spec.ts
+++ b/common/integration/ppaasteststatus.spec.ts
@@ -37,7 +37,8 @@ describe("PpaasTestStatus", () => {
       errors: ["Test Error"],
       version: PEWPEW_VERSION_LATEST,
       queueName: "unittest",
-      userId: "unittestuser"
+      userId: "unittestuser",
+      changelogs: ["Test Changelog"]
     };
     ppaasTestWriteStatus = new PpaasTestStatus(ppaasTestId, testStatus);
   });

--- a/common/integration/ppaasteststatus.spec.ts
+++ b/common/integration/ppaasteststatus.spec.ts
@@ -171,6 +171,7 @@ describe("PpaasTestStatus", () => {
       for (const key in actualTestMessage) {
         expect(JSON.stringify(actualTestMessage[key as keyof TestStatusMessage]), key).to.equal(JSON.stringify(testStatus[key as keyof TestStatusMessage]));
       }
+      expect(JSON.stringify(actualTestMessage.changelogs), "changelogs").to.equal(JSON.stringify(testStatus.changelogs));
       done();
     });
   });

--- a/common/src/ppaasteststatus.ts
+++ b/common/src/ppaasteststatus.ts
@@ -29,6 +29,7 @@ export class PpaasTestStatus implements TestStatusMessage {
   public version?: string;
   public queueName?: string;
   public userId?: string;
+  public changelogs: string[] | undefined;
   protected ppaasTestId: PpaasTestId;
   protected lastModifiedRemote: Date;
   protected url: string | undefined;
@@ -55,6 +56,7 @@ export class PpaasTestStatus implements TestStatusMessage {
     this.version = testStatusMessage.version;
     this.queueName = testStatusMessage.queueName;
     this.userId = testStatusMessage.userId;
+    this.changelogs = testStatusMessage.changelogs;
     this.lastModifiedRemote = new Date(0); // It hasn't been downloaded yet
   }
 
@@ -70,7 +72,8 @@ export class PpaasTestStatus implements TestStatusMessage {
       errors: this.errors,
       version: this.version,
       queueName: this.queueName,
-      userId: this.userId
+      userId: this.userId,
+      changelogs: this.changelogs
     };
     return testStatus;
   }

--- a/common/test/ppaasteststatus.spec.ts
+++ b/common/test/ppaasteststatus.spec.ts
@@ -50,7 +50,8 @@ describe("PpaasTestStatus", () => {
       errors: ["Test Error"],
       version: PEWPEW_VERSION_LATEST,
       queueName: "unittest",
-      userId: "unittestuser"
+      userId: "unittestuser",
+      changelogs: ["Test Changelog"]
     };
     testFilename = ppaasteststatus.createS3Filename(ppaasTestId);
     testFolder = ppaasTestId.s3Folder;

--- a/common/test/ppaasteststatus.spec.ts
+++ b/common/test/ppaasteststatus.spec.ts
@@ -264,6 +264,8 @@ describe("PpaasTestStatus", () => {
           expect(emptyTestStatus.ipAddress, "ipAddress").to.equal(testStatus.ipAddress);
           expect(emptyTestStatus.version, "version").to.equal(testStatus.version);
           expect(emptyTestStatus.queueName, "queueName").to.equal(testStatus.queueName);
+          expect(emptyTestStatus.userId, "userId").to.equal(testStatus.userId);
+          expect(JSON.stringify(emptyTestStatus.changelogs), "changelogs").to.equal(JSON.stringify(testStatus.changelogs));
           done();
         }).catch((error) => {
           log("PpaasTestStatus.readStatus error", LogLevel.ERROR, error);

--- a/common/types/ppaascommessage.ts
+++ b/common/types/ppaascommessage.ts
@@ -15,3 +15,12 @@ export interface CommunicationsMessage {
   messageType: MessageType;
   messageData: any;
 }
+
+export interface StopKillMessageData {
+  userId?: string;
+}
+
+export interface UpdateYamlMessageData {
+  filename: string;
+  userId?: string;
+}

--- a/common/types/ppaasteststatus.ts
+++ b/common/types/ppaasteststatus.ts
@@ -22,4 +22,5 @@ export interface TestStatusMessage {
   version?: string;
   queueName?: string;
   userId?: string;
+  changelogs?: string[];
 }

--- a/controller/components/TestInfo/index.tsx
+++ b/controller/components/TestInfo/index.tsx
@@ -13,8 +13,8 @@ import {
   TestManagerMessage
 } from "../../types";
 import { Button, LinkButton, defaultButtonTheme } from "../LinkButton";
-import { Danger, Success } from "../Alert";
-import { Div, DivRight } from "../Div";
+import { Column, Div, DivRight } from "../Div";
+import { Danger, Info, Success } from "../Alert";
 import { LogLevel, log } from "../../src/log";
 import React, { useState } from "react";
 import axios, { AxiosResponse } from "axios";
@@ -253,6 +253,14 @@ The previous "Stop" will automatically send a "Kill" after a few minutes if pewp
       </Div>
       {state.message && <Success>{state.message}{state.messageId && <><br/>MessageId: {state.messageId}</>}</Success>}
       {state.error && <Danger>Error: {state.error}</Danger>}
+      {testData.changelogs && testData.changelogs.length > 0 && <Info>
+        <Column>
+        Test Activity Log
+        <ul>
+          {testData.changelogs.map((entry: string, index: number) => <li key={"changelog" + index}>{entry}</li>)}
+        </ul>
+        </Column>
+      </Info>}
     </React.Fragment>
   );
 };

--- a/controller/components/TestInfo/story.tsx
+++ b/controller/components/TestInfo/story.tsx
@@ -57,7 +57,8 @@ const fullTest: Required<TestData> = {
   errors: ["error1", "error2", "error3"],
   version: latestPewPewVersion,
   queueName: "unittest",
-  userId: "bruno.madrigal@pewpew.org"
+  userId: "bruno.madrigal@pewpew.org",
+  changelogs: ["StopTest received from bruno.madrigal@pewpew.org"]
 };
 const props: TestInfoStorybookProps = {
   testData: { ...basicTest, status: TestStatus.Created, lastUpdated: fullTest.lastUpdated }
@@ -142,6 +143,28 @@ const scheduledPastProps: TestInfoStorybookProps = {
     status: TestStatus.Scheduled,
     startTime: Date.now() + 600000,
     endTime: Date.now() + 900000
+  }
+};
+
+const propsWithChangelogs: TestInfoStorybookProps = {
+  testData: {
+    ...fullTest,
+    status: TestStatus.Finished,
+    changelogs: [
+      "Received StopTest message from controller by bruno.madrigal@pewpew.org"
+    ]
+  }
+};
+
+const propsWithMultipleChangelogs: TestInfoStorybookProps = {
+  testData: {
+    ...fullTest,
+    status: TestStatus.Failed,
+    changelogs: [
+      "UpdateYaml received from mirabel.madrigal@pewpew.org at 2026-06-22T14:30:00.000Z",
+      "UpdateYaml received from dolores.madrigal@pewpew.org at 2026-06-22T15:10:00.000Z",
+      "Received KillTest message from controller by antonio.madrigal@pewpew.org"
+    ]
   }
 };
 
@@ -257,3 +280,25 @@ export const ScheduledFuture = () => (
     <TestInfo {...scheduledPastProps} />
   </React.Fragment>
 );
+
+export const WithChangelogs = {
+  render: () => (
+    <React.Fragment>
+      <GlobalStyle />
+      <TestInfo {...propsWithChangelogs} />
+    </React.Fragment>
+  ),
+
+  name: "WithChangelogs"
+};
+
+export const WithMultipleChangelogs = {
+  render: () => (
+    <React.Fragment>
+      <GlobalStyle />
+      <TestInfo {...propsWithMultipleChangelogs} />
+    </React.Fragment>
+  ),
+
+  name: "WithMultipleChangelogs"
+};

--- a/controller/components/TestInfo/story.tsx
+++ b/controller/components/TestInfo/story.tsx
@@ -1,4 +1,5 @@
 import TestInfo, { TestInfoProps } from ".";
+import { AuthPermission } from "../../types/auth";
 import { GlobalStyle } from "../Layout";
 // Must reference the PpaasTestId file directly or we pull in stuff that won't compile on the client
 import { PpaasTestId } from "@fs/ppaas-common/dist/src/ppaastestid";
@@ -102,6 +103,8 @@ const propsWithDownloadFiles: TestInfoStorybookProps = {
       ...fullTest.resultsFileLocation
     ]
   },
+  authPermission: AuthPermission.Admin,
+  userId: "mirabel.madrigal@pewpew.org",
   downloadFiles: [
     "Story.yaml",
     "Story.csv",
@@ -109,6 +112,28 @@ const propsWithDownloadFiles: TestInfoStorybookProps = {
     "app-ppaas-pewpew-basicwithenv20250918T170447046-error.json",
     "stats-basicwithenv20250918T170447046.json"
   ]
+};
+
+const propsWithDownloadButtonAsOwner: TestInfoStorybookProps = {
+  testData: {
+    ...basicTest,
+    status: TestStatus.Running,
+    resultsFileLocation: [...fullTest.resultsFileLocation],
+    userId: fullTest.userId
+  },
+  authPermission: AuthPermission.User,
+  userId: fullTest.userId
+};
+
+const propsWithDownloadButtonHiddenNonOwner: TestInfoStorybookProps = {
+  testData: {
+    ...basicTest,
+    status: TestStatus.Finished,
+    resultsFileLocation: [...fullTest.resultsFileLocation],
+    userId: fullTest.userId
+  },
+  authPermission: AuthPermission.User,
+  userId: "mirabel.madrigal@pewpew.org"
 };
 
 const propsWithStopSuccess: TestInfoStorybookProps = {
@@ -232,6 +257,28 @@ export const WithDownloadFiles = {
   ),
 
   name: "WithDownloadFiles"
+};
+
+export const WithDownloadButtonAsOwner = {
+  render: () => (
+    <React.Fragment>
+      <GlobalStyle />
+      <TestInfo {...propsWithDownloadButtonAsOwner} />
+    </React.Fragment>
+  ),
+
+  name: "WithDownloadButtonAsOwner"
+};
+
+export const WithDownloadButtonHiddenNonOwner = {
+  render: () => (
+    <React.Fragment>
+      <GlobalStyle />
+      <TestInfo {...propsWithDownloadButtonHiddenNonOwner} />
+    </React.Fragment>
+  ),
+
+  name: "WithDownloadButtonHiddenNonOwner"
 };
 
 export const WithSuccess = {

--- a/controller/components/TestInfo/test-info.spec.tsx
+++ b/controller/components/TestInfo/test-info.spec.tsx
@@ -214,6 +214,35 @@ describe("TestInfo Component", () => {
     });
   });
 
+  describe("download button visibility", () => {
+    const testWithOwner: TestData = { ...baseTestData, userId: "owner@example.com" };
+
+    it("does not render the download button when authPermission is not provided", () => {
+      render(<TestInfo testData={testWithOwner} />);
+      expect(screen.queryByText("Download Test Files")).not.toBeInTheDocument();
+    });
+
+    it("renders the download button for Admin even when userId does not match testData.userId", () => {
+      render(<TestInfo testData={testWithOwner} authPermission={AuthPermission.Admin} userId="other@example.com" />);
+      expect(screen.getByText("Download Test Files")).toBeInTheDocument();
+    });
+
+    it("renders the download button when userId matches testData.userId", () => {
+      render(<TestInfo testData={testWithOwner} authPermission={AuthPermission.User} userId="owner@example.com" />);
+      expect(screen.getByText("Download Test Files")).toBeInTheDocument();
+    });
+
+    it("does not render the download button when userId does not match testData.userId", () => {
+      render(<TestInfo testData={testWithOwner} authPermission={AuthPermission.User} userId="other@example.com" />);
+      expect(screen.queryByText("Download Test Files")).not.toBeInTheDocument();
+    });
+
+    it("does not render the download button when testData has no userId and user is not Admin", () => {
+      render(<TestInfo testData={baseTestData} authPermission={AuthPermission.User} userId="user@example.com" />);
+      expect(screen.queryByText("Download Test Files")).not.toBeInTheDocument();
+    });
+  });
+
   describe("canDownloadTestFiles", () => {
     it("returns false when authPermission is undefined", () => {
       expect(canDownloadTestFiles(undefined, "user@example.com", "user@example.com")).toBe(false);

--- a/controller/src/testmanager.ts
+++ b/controller/src/testmanager.ts
@@ -39,9 +39,11 @@ import {
   PpaasTestId,
   PpaasTestMessage,
   PpaasTestStatus,
+  StopKillMessageData,
   TestMessage,
   TestStatus,
   TestStatusMessage,
+  UpdateYamlMessageData,
   YamlParser,
   log,
   logger,
@@ -1562,10 +1564,14 @@ export abstract class TestManager {
         log(`PUT testId: ${testIdString}. ${yamlFile.originalFilename || yamlFile.filepath} uploaded to S3`, LogLevel.DEBUG, testId);
 
         // Create our message in the communications queue
+        const updateYamlMessageData: UpdateYamlMessageData = {
+          filename: yamlFile.originalFilename || yamlFile.filepath,
+          userId: authPermissions.userId || undefined
+        };
         const ppaasCommunicationsMessage = new PpaasS3Message({
           testId,
           messageType: MessageType.UpdateYaml,
-          messageData: yamlFile.originalFilename || yamlFile.filepath
+          messageData: updateYamlMessageData
         });
         const messageId: string | undefined = await ppaasCommunicationsMessage.send();
         log ("Load Test updated", LogLevel.INFO, { testId, communicationsMessage: ppaasCommunicationsMessage.sanitizedCopy(), messageId, authPermissions: getLogAuthPermissions(authPermissions) });
@@ -1613,10 +1619,11 @@ export abstract class TestManager {
         }
         log(`PUT testId: ${testIdString} found in S3`, LogLevel.DEBUG, testId);
 
+        const stopKillMessageData: StopKillMessageData = { userId: authPermissions.userId || undefined };
         const ppaasCommunicationsMessage = new PpaasS3Message({
           testId,
           messageType: killTest ? MessageType.KillTest : MessageType.StopTest,
-          messageData: undefined
+          messageData: stopKillMessageData
         });
         const messageId: string | undefined = await ppaasCommunicationsMessage.send();
         log ("Load Test stopped", LogLevel.INFO, { testId, communicationsMessage: ppaasCommunicationsMessage.sanitizedCopy(), messageId, authPermissions: getLogAuthPermissions(authPermissions) });


### PR DESCRIPTION
Adds a `changelogs` audit trail to `PpaasTestStatus` so operators can see who stopped, killed, or updated the YAML of a running test. The userId flows from the controller through S3 messages to the agent, is persisted in the test status, and is displayed in the TestInfo component as a "Test Activity Log." Also includes PERF-4204: Storybook and render tests for `TestInfo` download button visibility.

## Reasoned Changes

### New `changelogs` field on `TestStatusMessage` and `PpaasTestStatus`

**What:** A new optional `changelogs?: string[]` field is added to the `TestStatusMessage` interface and propagated through `PpaasTestStatus` constructor, `getTestStatusMessage()`, and S3 serialization.

**Why:** Auditing who stopped, killed, or updated a running test was impossible because only the start userId was captured and any stop/kill signal was silently merged into the existing `errors` array. The field is kept separate from `errors` so informational audit events (stop/kill/updateYaml) can be displayed distinctly from actual test failures. Keeping it optional preserves backward compatibility with pre-existing status objects that predate this PR.

### Controller passes `userId` into stop/kill/updateYaml S3 messages

**What:** `testmanager.ts` now wraps stop, kill, and updateYaml communications messages in typed `StopKillMessageData` and `UpdateYamlMessageData` objects that carry `authPermissions.userId`.

**Why:** Without the userId in the message payload the agent had no way to attribute stop/kill/updateYaml actions back to the operator who triggered them. The controller already holds `authPermissions.userId` at the call site; wrapping it in a typed interface makes the contract explicit and avoids stringly-typed `messageData: any` usage at the controller layer. The `messageData: any` field on `CommunicationsMessage` itself is intentionally preserved to avoid a larger refactor of `PpaasS3Message` serialization.

### Agent reads `userId` from message and appends to `changelogs`

**What:** `pewpewtest.ts` deserializes the incoming message data into the typed interfaces, passes `userId` to `stop()`, and appends a changelog entry synchronously in `stop()` before delegating to `internalStop()` or `internalKill()`; `UpdateYaml` appends its changelog entry after parsing and then calls `writeTestStatus()`.

**Why:** The changelog entry for stop/kill is written synchronously before any async subprocess signal is sent so that unit tests can assert on state immediately without needing to await process termination. `UpdateYaml` writes its changelog after the YAML parse attempt so the timestamp in the entry reflects actual processing time rather than message receipt. The previous behavior of adding stop/kill to `errors` is removed entirely; nothing now falls back to `errors` for these events, which is a deliberate behavioral change.

### Typed `StopKillMessageData` and `UpdateYamlMessageData` interfaces

**What:** Two new exported interfaces are added to `common/types/ppaascommessage.ts` formalizing the shape of `messageData` for stop, kill, and updateYaml messages.

**Why:** Previously `UpdateYaml` messages carried a raw filename string as `messageData`, which was never formally typed; adding `userId` to that payload required promoting the shape to an interface. Making both interfaces optional on `userId` allows old agents (without this code) to send messages without breaking newer controllers, and vice versa. The interfaces live in the common package so both controller and agent share the exact same type without duplication.

### UI: `TestInfo` renders changelog entries as an `Info` (blue) alert list

**What:** `controller/components/TestInfo/index.tsx` conditionally renders `changelogs` as an unordered list inside an `Info` alert when the array is non-empty.

**Why:** The conversation explicitly separated changelog display from error display so operators can visually distinguish informational audit events (blue) from test failures (yellow/red). Placing the rendering in `TestInfo` rather than `teststatus.tsx` keeps it Storybook-testable in isolation. No pagination or truncation is implemented; all changelog entries render unconditionally.

### PERF-4204: Storybook stories and component render tests for download button visibility

**What:** `story.tsx` gains four new story variants (`WithDownloadButtonAsOwner`, `WithDownloadButtonHiddenNonOwner`, `WithChangelogs`, `WithMultipleChangelogs`) and `test-info.spec.tsx` gains a new `describe("download button visibility")` block with five render assertions.

**Why:** Download button visibility logic (gated by `authPermission` and ownership match) lacked any Storybook or unit-test coverage, creating a regression risk whenever auth logic changed. The tests use `screen.queryByText` / `screen.getByText` against the rendered DOM rather than testing implementation, which matches the project's behavior-first testing philosophy.

## Risk Assessment

Risk concentrates at the agent's message deserialization boundary and the stop/kill changelog persistence path — two areas where silent failures could produce an incomplete or misleading audit trail without surfacing any errors.

### Highest-Risk Areas

1. **agent/src/pewpewtest.ts:963** — `messageToHandle.messageData as UpdateYamlMessageData | undefined` succeeds silently when `messageData` is the legacy bare string; old-format messages (sent by a pre-deploy controller or replayed from S3) will produce a `UpdateYaml received at <timestamp>` changelog entry with no userId, indistinguishable from a new-format message with no userId intentionally omitted — auditability gap for the deployment window.

2. **agent/src/pewpewtest.ts:994** — `writeTestStatus()` is now called unconditionally on every `UpdateYaml` message, including when `bypassParser: true` or when runtime did not change; this is a behavioral expansion from the pre-PR code where `writeTestStatus()` was only called when the runtime actually changed — worth verifying no excessive S3 write pressure results from tests that receive many YAML updates.

3. **controller/src/testmanager.ts** — `authPermissions.userId || undefined` silently drops an empty-string `userId` (`""`) — if the auth system ever issues a token with `userId: ""`, the changelog will show no user rather than surfacing the misconfiguration.

4. **controller/components/TestInfo/index.tsx:256–263** — Changelog list renders all entries with no length cap; a test with many `UpdateYaml` cycles could produce dozens of entries that push other UI controls off-screen with no scroll container or "show more" affordance.

## Review Hotspots

1. **agent/src/pewpewtest.ts:944–1001** — The `switch` block was restructured to add braces for all three cases in the same commit that added changelog logic; diff is noisier than the behavioral change warrants — focus review on the `stop()` call signature change and the `writeTestStatus()` placement.

2. **agent/src/pewpewtest.ts:980–995** — `writeTestStatus()` moved from conditional (runtime-changed branch) to unconditional (after full `UpdateYaml` handling); verify this is intentional for the changelog write and acceptable in terms of S3 write frequency.

3. **agent/test/pewpewtest.spec.ts:273–298** — New `stop()` unit tests assert synchronous state by calling `stop(...).catch(() => {})` fire-and-forget; this encodes an implicit timing assumption — if the changelog write ever becomes async, these tests will pass with stale state.

## Testing

**Unit tests added:**
- `common/test/ppaasteststatus.spec.ts` — explicit `changelogs` assertion in `readStatus should update values`
- `agent/test/pewpewtest.spec.ts` — 3 new `stop()` tests (no userId, with userId, kill with userId); `changelogs` assertions in all 6 `copyTestStatus` tests
- `controller/components/TestInfo/test-info.spec.tsx` — 5 download button visibility render tests

**Integration/createtest tests updated:**
- `agent/createtest/pewpewtest.spec.ts` — changelogs assertions after stop/kill/updateYaml; UpdateYaml messageData promoted from bare string to `UpdateYamlMessageData` object
- `agent/integration/pewpewtest.spec.ts` — changelogs + userId assertions after stop/updateYaml; messages now carry `StopKillMessageData`/`UpdateYamlMessageData` with userId
- `common/integration/ppaasteststatus.spec.ts` — explicit changelogs assertion alongside generic key-loop check

**Storybook:** `WithChangelogs` and `WithMultipleChangelogs` stories added to `TestInfo`

**Known gaps:** Integration tests with userId run against real AWS — not executed in this session. The old string-format `UpdateYaml` messageData backward-compatibility path is not directly tested.

- [ ] Code follows project style guidelines
- [ ] Tests added/updated and passing
- [ ] Documentation updated if needed
- [ ] No breaking changes (or documented if present)
- [ ] Reviewed my own code for obvious issues