### PR TITLE
PERF-4204 Allow test owners to download their own test files via API

### DIFF
--- a/controller/pages/api/download.ts
+++ b/controller/pages/api/download.ts
@@ -1,8 +1,9 @@
-import { AuthPermission, AuthPermissions, TestManagerError } from "../../types";
+import { AuthPermission, AuthPermissions, TestDataResponse, TestManagerError } from "../../types";
 import { LogLevel, PpaasTestId, log, ppaasteststatus, s3 } from "@fs/ppaas-common";
 import { NextApiRequest, NextApiResponse } from "next";
 import { ENCRYPTED_ENVIRONMENT_VARIABLES_FILENAME } from "../../src/ppaasencryptenvfile";
 import type { GetObjectCommandOutput } from "@aws-sdk/client-s3";
+import { TestManager } from "../../src/testmanager";
 import { authApi } from "../../src/authserver";
 import { createErrorResponse } from "../../src/util";
 import { getS3Response } from "../../src/s3";
@@ -21,9 +22,7 @@ export function isValidFileName (ppaasTestId: PpaasTestId, filename: string): bo
 }
 
 export default async (req: NextApiRequest, res: NextApiResponse<string[] | GetObjectCommandOutput["Body"] | Buffer | TestManagerError>): Promise<void> => {
-  // Allow Read-Only to view the schedule, but not modify
-
-  const authPermissions: AuthPermissions | undefined = await authApi(req, res, AuthPermission.Admin);
+  const authPermissions: AuthPermissions | undefined = await authApi(req, res, AuthPermission.ReadOnly);
   if (!authPermissions) {
     // If it's undefined we failed auth and already have set a response
     return;
@@ -45,6 +44,17 @@ export default async (req: NextApiRequest, res: NextApiResponse<string[] | GetOb
       } catch (error) {
         res.status(400).json(createErrorResponse(req, error, LogLevel.ERROR));
         return;
+      }
+
+      // Admins can download any test files. Non-admins can only download files from tests they own.
+      // If testData has no userId, only admins can download (we cannot verify ownership).
+      if (authPermissions.authPermission < AuthPermission.Admin) {
+        const testDataResponse = await TestManager.getTest(testId);
+        const testData = testDataResponse.status < 300 ? (testDataResponse as TestDataResponse).json : undefined;
+        if (!testData?.userId || authPermissions.userId !== testData.userId) {
+          res.status(403).json({ message: "You do not have permission to download these test files" });
+          return;
+        }
       }
       if (!file) {
         const s3Objects = await s3.listFiles(ppaasTestId.s3Folder);

--- a/controller/pages/api/download.ts
+++ b/controller/pages/api/download.ts
@@ -50,8 +50,12 @@ export default async (req: NextApiRequest, res: NextApiResponse<string[] | GetOb
       // If testData has no userId, only admins can download (we cannot verify ownership).
       if (authPermissions.authPermission < AuthPermission.Admin) {
         const testDataResponse = await TestManager.getTest(testId);
+        if (testDataResponse.status >= 300) {
+          log(`Download ownership check: TestManager.getTest failed for testId ${testId} with status ${testDataResponse.status}`, LogLevel.WARN, { testId, file, testDataResponse });
+        }
         const testData = testDataResponse.status < 300 ? (testDataResponse as TestDataResponse).json : undefined;
         if (!testData?.userId || authPermissions.userId !== testData.userId) {
+          log(`Download access denied for userId=${authPermissions.userId} on testId=${testId}: testData.userId=${testData?.userId}`, LogLevel.WARN, { testId, file, userId: authPermissions.userId, testDataUserId: testData?.userId });
           res.status(403).json({ message: "You do not have permission to download these test files" });
           return;
         }


### PR DESCRIPTION
## Summary

Non-admin test owners could see the "Download Test Files" button (added in PR #390) but receive a 403 from the download API, which was still gated to Admins only. This PR extends the download endpoint to verify test ownership server-side, granting access to the test's creator while keeping all other non-admin users blocked.

## Reasoned Changes

### Download API ownership gate for non-admin test owners
**What:** The download API's minimum auth level is lowered from `AuthPermission.Admin` to `AuthPermission.ReadOnly`, with a secondary server-side ownership check for callers below Admin.
**Why:** Non-admin test owners could see the "Download Test Files" button (landed in PR #390) but hit a 403 from the API, creating broken UX. The fix calls `TestManager.getTest(testId)` to retrieve the test record and compares `authPermissions.userId` against `testData.userId` before allowing the download. Tests with no `userId` field remain admin-only since ownership cannot be verified, accepting an extra round-trip latency cost for non-admin requests in exchange for correct access control.

### Observability for ownership check failures
**What:** Two WARN-level log entries are added — one when `TestManager.getTest` returns a non-2xx response, and one for every 403 denial.
**Why:** Without logging, a transient `TestManager` failure (network blip, service unavailability) would produce a 403 indistinguishable from a legitimate permission denial, making the root cause invisible in logs. The `TestManager` failure log includes `testId`, `file`, and the full response for infrastructure debugging. The 403 log captures `userId`, `testId`, and `testData.userId` so operators can distinguish "test has no owner recorded" from "wrong user attempted access."

## Risk Assessment

Risk concentrates in the single boolean expression `authPermissions.userId !== testData.userId` — if `TestManager.getTest` errors for any reason (network blip, S3 latency, service unavailability), the download 403s for legitimate owners. This is now observable via the WARN log but the user still receives a permission-denied message rather than a retriable error.

### Highest-Risk Areas
1. **controller/pages/api/download.ts:51-62** — A `TestManager.getTest` failure now WARNs but still returns 403. The user experience is "you don't have permission" when the real cause is an infrastructure failure; this may warrant a follow-up to return 500/503 instead so clients can retry.

## Testing

- **Component render tests**: 5 tests in `controller/components/TestInfo/test-info.spec.tsx` verify download button visibility for Admin, matching userId, non-matching userId, and missing userId cases — all 408 tests passing.
- **`canDownloadTestFiles` unit tests**: 10 tests covering all `AuthPermission` enum values and ownership combinations.
- **Acceptance test gap**: Acceptance tests run with `AUTH_MODE` off, which causes `authApi` to return `AuthPermission.Admin` unconditionally — the non-admin ownership path in the API is not covered by automated acceptance tests. Manual verification would require an auth-on environment.
- **Build/lint**: Clean build and lint pass on `controller/pages/api/download.ts`.

## Checklist

- [x] Code follows project style guidelines (lint clean)
- [x] Tests added/updated and passing (408/408)
- [x] Documentation updated if needed
- [x] No breaking changes (Admins retain full access; new path only affects non-admin users)
- [x] Reviewed my own code for obvious issues