### PR TITLE
Clean up fork review findings: changelog wording, Javadoc, and TS type fix

### DIFF
--- a/agent/src/pewpewtest.ts
+++ b/agent/src/pewpewtest.ts
@@ -713,7 +713,7 @@ export class PewPewTest {
    */
   public async stop (killTest?: boolean, userId?: string): Promise<void> {
     this.stopCalled = true;
-    const changelogEntry = `Received ${killTest ? "KillTest" : "StopTest"} message from controller${userId ? ` by ${userId}` : ""}`;
+    const changelogEntry = `Received ${killTest ? "KillTest" : "StopTest"} request${userId ? ` by ${userId}` : ""}`;
     this.ppaasTestStatus.changelogs = [...(this.ppaasTestStatus.changelogs || []), changelogEntry];
     await this.writeTestStatus();
     return killTest ? this.internalKill() : this.internalStop();

--- a/controller/components/TestInfo/index.tsx
+++ b/controller/components/TestInfo/index.tsx
@@ -61,10 +61,10 @@ interface TestInfoStorybookProps extends TestInfoProps {
   error?: any;
 }
 
-/** Determines if a user can download test files based on their permissions and ownership
- * If the user is an admin, they can download any test files. If the user is a read-only user,
- * they can only download their own test files. If the user is a regular user, they cannot
- * download any test files and the download button is hidden.
+/** Determines if a user can download test files based on their permissions and ownership.
+ * Admins can download any test files. Non-admin users (User or ReadOnly) can download
+ * test files they own (when userId matches testDataUserId). Users without at least
+ * ReadOnly permission cannot download any test files.
  * @param authPermission The user's authentication permission level.
  * @param userId The ID of the user making the request.
  * @param testDataUserId The ID of the user who owns the test data.

--- a/controller/src/excelexport.ts
+++ b/controller/src/excelexport.ts
@@ -37,7 +37,9 @@ export const RESULT_COLUMNS: Column<ExcelResultRow>[] = [
 
 type WriteFn = (data: ExcelResultRow[], options: { columns: Column<ExcelResultRow>[]; sheet: string }) => { toFile: (fileName: string) => Promise<void> };
 
-export async function exportResultsToExcel (data: ExcelResultRow[], fileName: string, sheetName: string, writeFn: WriteFn = writeXlsxFile as unknown as WriteFn): Promise<void> {
+const defaultWriteFn: WriteFn = (data, options) => writeXlsxFile<ExcelResultRow>(data, options);
+
+export async function exportResultsToExcel (data: ExcelResultRow[], fileName: string, sheetName: string, writeFn: WriteFn = defaultWriteFn): Promise<void> {
   const result = writeFn(data, { columns: RESULT_COLUMNS, sheet: sheetName });
   await result.toFile(fileName);
 }


### PR DESCRIPTION
## Summary

Addresses three small issues surfaced in downstream fork reviews: a misleading changelog message, an inaccurate Javadoc comment, and an unsafe TypeScript cast.

## Reasoned Changes

### Changelog entry wording in agent stop handler
**What:** Changes the logged stop message from "message from controller" to "request" in `agent/src/pewpewtest.ts`.
**Why:** The original wording assumed stops always come from the controller; API-initiated stops made the log entry inaccurate. Generalizing to "request" keeps the log correct regardless of stop source.

### Javadoc correction for download permission logic in TestInfo
**What:** Rewrites the JSDoc comment on the download-permission helper in `controller/components/TestInfo/index.tsx` to accurately describe all three permission tiers.
**Why:** Fork reviewers identified that the comment misstated which user roles can download test files — specifically it said regular users cannot download any files, when non-admin users with at least ReadOnly permission can download their own files. The corrected comment aligns documentation with the actual conditional logic.

### TypeScript type fix for `exportResultsToExcel` default parameter
**What:** Replaces an `as unknown as WriteFn` double-cast in `controller/src/excelexport.ts` with a named `defaultWriteFn` const using an explicit generic type call.
**Why:** The cast suppressed TypeScript's type checker and was flagged in fork review as unsafe. The replacement wraps `writeXlsxFile<ExcelResultRow>` in a properly-typed lambda, eliminating the unsafe cast while preserving identical runtime behavior.

## Risk Assessment

Risk is minimal — all three changes are a string literal, a JSDoc comment, and a type-signature correction with no added logic branching. The only runtime-adjacent change is the `defaultWriteFn` wrapper; it behaves identically at runtime but surfaces type errors at compile time rather than silently — strictly safer.

### Highest-Risk Areas
1. **controller/src/excelexport.ts** — The new lambda wrapper must correctly satisfy the `WriteFn` generic; verify it resolves without requiring a cast at call sites.

## Testing

- Changes are limited to a log string, a JSDoc comment, and a TypeScript type signature — no behavioral logic was altered.
- Existing test suite covers the affected paths; no new tests added.

## Checklist

- [ ] Code follows project style guidelines
- [ ] Tests added/updated and passing
- [ ] Documentation updated if needed
- [ ] No breaking changes (or documented if present)
- [ ] Reviewed my own code for obvious issues