### PR TITLE
Fix WASM histogram leaks and race conditions in TestResults merge view

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything
+* @FamilySearch/PerformanceQA

--- a/controller/components/TestResults/index.tsx
+++ b/controller/components/TestResults/index.tsx
@@ -594,12 +594,12 @@ export const OverviewChart: React.FC<OverviewChartProps> = ({ displayData, merge
     if (node) {
       if (overviewChart) { overviewChart.destroy(); }
 
+      let cancelled = false;
       if (mergeEndpoints) {
         const mergedData = groupAndMergeByLabel(displayData, (b) => `${b.method} ${b.url}`);
         import("./charts").then(({ requestCountByEndpoint }) => {
-          setOverviewChart(requestCountByEndpoint(node, mergedData));
-          freeGroupedHistograms(mergedData);
-        });
+          if (!cancelled && node.isConnected) { setOverviewChart(requestCountByEndpoint(node, mergedData)); }
+        }).finally(() => { freeGroupedHistograms(mergedData); });
       } else {
         const endpointData: [string, DataPoint[]][] = displayData.map(([bucketId, dataPoints]) => {
           const tagList = Object.entries(bucketId)
@@ -612,9 +612,10 @@ export const OverviewChart: React.FC<OverviewChartProps> = ({ displayData, merge
           return [label, dataPoints];
         });
         import("./charts").then(({ requestCountByEndpoint }) => {
-          setOverviewChart(requestCountByEndpoint(node, endpointData));
+          if (!cancelled && node.isConnected) { setOverviewChart(requestCountByEndpoint(node, endpointData)); }
         });
       }
+      return () => { cancelled = true; };
     }
   }, [displayData, mergeEndpoints]);
 
@@ -653,10 +654,11 @@ export const HostChart: React.FC<{ displayData: ParsedFileEntry[] }> = ({ displa
         try { return new URL(bucketId.url).hostname; } catch { return bucketId.url; }
       });
 
+      let cancelled = false;
       import("./charts").then(({ requestCountByEndpoint, mergeAgentColors }) => {
-        setHostChart(requestCountByEndpoint(node, hostData, mergeAgentColors));
-        freeGroupedHistograms(hostData);
-      });
+        if (!cancelled && node.isConnected) { setHostChart(requestCountByEndpoint(node, hostData, mergeAgentColors)); }
+      }).finally(() => { freeGroupedHistograms(hostData); });
+      return () => { cancelled = true; };
     }
   }, [displayData]);
 
@@ -696,11 +698,12 @@ export const AgentChart: React.FC<AgentChartProps> = ({ displayData, agentTimeSe
     if (node) {
       if (agentChart) { agentChart.destroy(); }
 
+      let cancelled = false;
       if (agentTimeSeries && agentTimeSeries.length > 0) {
         import("./charts").then(({ requestCountByAgentSeries, mergeAgentColors }) => {
-          setAgentChart(requestCountByAgentSeries(node, agentTimeSeries, mergeAgentColors));
+          if (!cancelled && node.isConnected) { setAgentChart(requestCountByAgentSeries(node, agentTimeSeries, mergeAgentColors)); }
         });
-        return;
+        return () => { cancelled = true; };
       }
 
       // Fallback: group by agent/host/machine/source tag from BucketId.
@@ -711,9 +714,9 @@ export const AgentChart: React.FC<AgentChartProps> = ({ displayData, agentTimeSe
       );
 
       import("./charts").then(({ requestCountByEndpoint, mergeAgentColors }) => {
-        setAgentChart(requestCountByEndpoint(node, agentData, mergeAgentColors));
-        freeGroupedHistograms(agentData);
-      });
+        if (!cancelled && node.isConnected) { setAgentChart(requestCountByEndpoint(node, agentData, mergeAgentColors)); }
+      }).finally(() => { freeGroupedHistograms(agentData); });
+      return () => { cancelled = true; };
     }
   }, [displayData, agentTimeSeries]);
 
@@ -1296,9 +1299,11 @@ export const TestResults = React.memo(({ testData, initialResultsIndex, onResult
     for (const parsed of allParsed) { freeParsedEntries(parsed); }
 
     setState((old) => {
-      // Free the previous merged data before replacing it
       freeParsedEntries(old.mergedData);
-      return { ...old, mergedData: merged, mergedAgentTimeSeries: agentTimeSeries, mergedTestIds: fileLabels };
+      freeHistograms(undefined, old.summaryData, undefined);
+      const mergedTime = minMaxTime(merged);
+      const mergedSummary = getSummaryData({ filteredData: merged, summaryTagFilter: old.summaryTagFilter, summaryTagValueFilter: old.summaryTagValueFilter });
+      return { ...old, mergedData: merged, mergedAgentTimeSeries: agentTimeSeries, mergedTestIds: fileLabels, minMaxTime: mergedTime, summaryData: mergedSummary };
     });
     // Sync additional testIds (all labels except the current test) to the URL
     onMergeTestIdsChangeRef.current?.(fileLabels.slice(1));
@@ -1307,7 +1312,10 @@ export const TestResults = React.memo(({ testData, initialResultsIndex, onResult
   const onClearMerge = useCallback(() => {
     setState((old) => {
       freeParsedEntries(old.mergedData);
-      return { ...old, mergedData: undefined, mergedAgentTimeSeries: [], mergedTestIds: [] };
+      freeHistograms(undefined, old.summaryData, undefined);
+      const restoredTime = old.resultsData ? minMaxTime(old.resultsData) : undefined;
+      const restoredSummary = getSummaryData({ filteredData: old.filteredData || old.resultsData, summaryTagFilter: old.summaryTagFilter, summaryTagValueFilter: old.summaryTagValueFilter });
+      return { ...old, mergedData: undefined, mergedAgentTimeSeries: [], mergedTestIds: [], minMaxTime: restoredTime, summaryData: restoredSummary };
     });
     onMergeTestIdsChangeRef.current?.(undefined);
   }, []);

--- a/controller/components/TestResults/index.tsx
+++ b/controller/components/TestResults/index.tsx
@@ -33,13 +33,13 @@ import { ModalObject, TestsListModal, useEffectModal } from "../Modal";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { TestData, TestManagerError, TestManagerMessage } from "../../types/testmanager";
 import axios, { AxiosResponse } from "axios";
+import { cloneParsedEntries, detectOverlap, mergeResults } from "./merge";
 import { formatError, formatPageHref, isTestManagerMessage } from "../../src/clientutil";
 import { Chart } from "chart.js";
 import { Danger } from "../Alert";
 import { MergeSearchModal } from "./MergeSearchModal";
 import { TestResultsCompare } from "../TestResultsCompare";
 import { TestStatus } from "@fs/ppaas-common/dist/types";
-import { mergeResults } from "./merge";
 import styled from "styled-components";
 
 const TimeTaken = styled.div`
@@ -1246,7 +1246,9 @@ export const TestResults = React.memo(({ testData, initialResultsIndex, onResult
   const onMergeLoad = useCallback(async (selectedTests: TestData[]): Promise<void> => {
     if (!state.resultsData) { return; }
 
-    const allParsed: ParsedFileEntry[][] = [state.resultsData];
+    // Clone base data before any await — prevents use-after-free if resultsData is freed
+    // by a concurrent reload or clear while we fetch additional agents' results.
+    const allParsed: ParsedFileEntry[][] = [cloneParsedEntries(state.resultsData)];
     const fileLabels: string[] = [testData.testId];
 
     for (const test of selectedTests) {
@@ -1262,6 +1264,13 @@ export const TestResults = React.memo(({ testData, initialResultsIndex, onResult
         fileLabels.push(test.testId);
       } catch (error) {
         log(`onMergeLoad: error loading ${test.testId}`, LogLevel.WARN, error);
+      }
+    }
+
+    if (!detectOverlap(allParsed)) {
+      if (!window.confirm("The selected tests don't appear to share any time buckets — they may not be concurrent agent runs. Merge anyway?")) {
+        for (const parsed of allParsed) { freeParsedEntries(parsed); }
+        return;
       }
     }
 
@@ -1283,8 +1292,8 @@ export const TestResults = React.memo(({ testData, initialResultsIndex, onResult
 
     const merged = mergeResults(allParsed);
 
-    // Free the intermediate parsed data from selected tests — mergeResults cloned what it needed
-    for (let i = 1; i < allParsed.length; i++) { freeParsedEntries(allParsed[i]); }
+    // Free all parsed data (including the base clone at [0]) — mergeResults cloned what it needed
+    for (const parsed of allParsed) { freeParsedEntries(parsed); }
 
     setState((old) => {
       // Free the previous merged data before replacing it

--- a/controller/components/TestResults/index.tsx
+++ b/controller/components/TestResults/index.tsx
@@ -1246,7 +1246,7 @@ export const TestResults = React.memo(({ testData, initialResultsIndex, onResult
     }
   };
 
-  const onMergeLoad = useCallback(async (selectedTests: TestData[]): Promise<void> => {
+  const onMergeLoad = useCallback(async (selectedTests: TestData[], userInitiated: boolean = true): Promise<void> => {
     if (!state.resultsData) { return; }
 
     // Clone base data before any await — prevents use-after-free if resultsData is freed
@@ -1270,7 +1270,7 @@ export const TestResults = React.memo(({ testData, initialResultsIndex, onResult
       }
     }
 
-    if (!detectOverlap(allParsed)) {
+    if (userInitiated && !detectOverlap(allParsed)) {
       if (!window.confirm("The selected tests don't appear to share any time buckets — they may not be concurrent agent runs. Merge anyway?")) {
         for (const parsed of allParsed) { freeParsedEntries(parsed); }
         return;
@@ -1364,7 +1364,7 @@ export const TestResults = React.memo(({ testData, initialResultsIndex, onResult
     if (initialMergeTestIds?.length && state.resultsData && !state.mergedData && !autoMergeTriggeredRef.current) {
       autoMergeTriggeredRef.current = true;
       const load = initialMergeTestData?.length
-        ? onMergeLoad(initialMergeTestData)
+        ? onMergeLoad(initialMergeTestData, false)
         : loadMergeByTestIds(initialMergeTestIds);
       load.catch((error: unknown) => {
         log("Auto-load merge error", LogLevel.WARN, error);

--- a/controller/components/TestResults/merge.spec.ts
+++ b/controller/components/TestResults/merge.spec.ts
@@ -10,7 +10,7 @@ vi.mock("@fs/hdr-histogram-wasm", () => {
 });
 
 import { DataPoint, ParsedFileEntry } from "./model";
-import { detectOverlap, mergeResults } from "./merge";
+import { cloneParsedEntries, detectOverlap, mergeResults } from "./merge";
 
 function makeDataPoint (timeSec: number, statusCounts: Record<string, number> = { "200": 1 }): DataPoint {
   return new DataPoint({
@@ -57,6 +57,37 @@ describe("detectOverlap", () => {
     const file2: ParsedFileEntry[] = [[GET_ENDPOINT, [makeDataPoint(2000)]]];
     const file3: ParsedFileEntry[] = [[GET_ENDPOINT, [makeDataPoint(2000)]]];
     expect(detectOverlap([file1, file2, file3])).toBe(false);
+  });
+});
+
+describe("cloneParsedEntries", () => {
+  it("returns DataPoints with independent histograms, statusCounts, and testErrors", () => {
+    const dp = makeDataPoint(1000, { "200": 1 });
+    const file: ParsedFileEntry[] = [[GET_ENDPOINT, [dp]]];
+    const [, clonedPoints] = cloneParsedEntries(file)[0];
+    const clonedDp = clonedPoints[0];
+
+    expect(clonedDp).not.toBe(dp);
+    expect(clonedDp.rttHistogram).not.toBe(dp.rttHistogram);
+    expect(clonedDp.statusCounts).not.toBe(dp.statusCounts);
+    expect(clonedDp.testErrors).not.toBe(dp.testErrors);
+
+    // Mutating the clone must not affect the source
+    clonedDp.statusCounts["200"] = 999;
+    clonedDp.rttHistogram.free();
+    expect(dp.statusCounts["200"]).toBe(1);
+    expect(dp.rttHistogram.free).not.toHaveBeenCalled();
+  });
+
+  it("preserves bucket identity and values before mutation", () => {
+    const dp = makeDataPoint(1000, { "200": 3 });
+    const file: ParsedFileEntry[] = [[GET_ENDPOINT, [dp]]];
+    const [bucketId, clonedPoints] = cloneParsedEntries(file)[0];
+
+    expect(bucketId).toBe(GET_ENDPOINT);
+    expect(clonedPoints).toHaveLength(1);
+    expect(clonedPoints[0].statusCounts).toEqual({ "200": 3 });
+    expect(clonedPoints[0].time.getTime()).toBe(dp.time.getTime());
   });
 });
 

--- a/controller/components/TestResults/merge.ts
+++ b/controller/components/TestResults/merge.ts
@@ -39,6 +39,10 @@ function createBucketKey (bucketId: BucketId): string {
  * For each endpoint bucket: DataPoints at the same timestamp are merged (histograms
  * combined, status counts summed). Endpoints present in only some files are included.
  */
+export function cloneParsedEntries (entries: ParsedFileEntry[]): ParsedFileEntry[] {
+  return entries.map(([bucketId, dataPoints]) => [bucketId, dataPoints.map((dp) => dp.clone())] as ParsedFileEntry);
+}
+
 export function mergeResults (resultsArray: ParsedFileEntry[][]): ParsedFileEntry[] {
   const bucketMap = new Map<string, [BucketId, Map<number, DataPoint>]>();
 

--- a/controller/components/TestResults/merge.ts
+++ b/controller/components/TestResults/merge.ts
@@ -31,6 +31,11 @@ function createBucketKey (bucketId: BucketId): string {
   return JSON.stringify(sortedEntries);
 }
 
+// Deep-clones parsed entries so callers can safely free/mutate the source without affecting the clone.
+export function cloneParsedEntries (entries: ParsedFileEntry[]): ParsedFileEntry[] {
+  return entries.map(([bucketId, dataPoints]) => [bucketId, dataPoints.map((dp) => dp.clone())] as ParsedFileEntry);
+}
+
 /**
  * Merges N sets of parsed results into a single unified result set.
  * Used when a test is spread across multiple agents — each agent produces its own
@@ -39,10 +44,6 @@ function createBucketKey (bucketId: BucketId): string {
  * For each endpoint bucket: DataPoints at the same timestamp are merged (histograms
  * combined, status counts summed). Endpoints present in only some files are included.
  */
-export function cloneParsedEntries (entries: ParsedFileEntry[]): ParsedFileEntry[] {
-  return entries.map(([bucketId, dataPoints]) => [bucketId, dataPoints.map((dp) => dp.clone())] as ParsedFileEntry);
-}
-
 export function mergeResults (resultsArray: ParsedFileEntry[][]): ParsedFileEntry[] {
   const bucketMap = new Map<string, [BucketId, Map<number, DataPoint>]>();
 

--- a/controller/components/TestResults/model.ts
+++ b/controller/components/TestResults/model.ts
@@ -239,7 +239,7 @@ function asBucketEntry (b: unknown): BucketEntry | Error {
   }
   if (!Array.isArray(b[1])) {
     return new Error(
-      `expected second value in bucket entry array to be an array bug got: ${JSON.stringify(
+      `expected second value in bucket entry array to be an array but got: ${JSON.stringify(
         b[1]
       )}`
     );

--- a/controller/components/TestResultsCompare/index.tsx
+++ b/controller/components/TestResultsCompare/index.tsx
@@ -498,14 +498,16 @@ const ComparisonRequestCountByEndpointChart: React.FC<{ displayData: ParsedFileE
   useEffect(() => {
     const node = canvasNodeRef.current;
     if (!node || allEndpoints.length === 0) { return; }
+    let cancelled = false;
     let currentChart: Chart;
     import("../TestResults/charts").then(({ requestCountByEndpoint }) => {
+      if (cancelled) { return; }
       if (chart) { chart.destroy(); }
       currentChart = requestCountByEndpoint(node, allEndpoints);
       setChart(currentChart);
       setHiddenDatasets(new Set());
     });
-    return () => { if (currentChart) { currentChart.destroy(); } };
+    return () => { cancelled = true; if (currentChart) { currentChart.destroy(); } };
   }, [allEndpoints]);
 
   const toggleDataset = (index: number) => {
@@ -562,14 +564,16 @@ const ComparisonRequestCountByHostChart: React.FC<{ displayData: ParsedFileEntry
   useEffect(() => {
     const node = canvasNodeRef.current;
     if (!node || hostGroups.length === 0) { return; }
+    let cancelled = false;
     let currentChart: Chart;
     import("../TestResults/charts").then(({ mergeAgentColors, requestCountByEndpoint }) => {
+      if (cancelled) { return; }
       if (chart) { chart.destroy(); }
       currentChart = requestCountByEndpoint(node, hostGroups, mergeAgentColors);
       setChart(currentChart);
       setHiddenDatasets(new Set());
     });
-    return () => { if (currentChart) { currentChart.destroy(); } };
+    return () => { cancelled = true; if (currentChart) { currentChart.destroy(); } };
   }, [hostGroups]);
 
   const toggleDataset = (index: number) => {
@@ -616,14 +620,16 @@ const ComparisonRequestCountByFileChart: React.FC<{ timeSeries: { time: Date; co
   useEffect(() => {
     const node = canvasNodeRef.current;
     if (!node || fileSeries.length === 0) { return; }
+    let cancelled = false;
     let currentChart: Chart;
     import("../TestResults/charts").then(({ requestCountByAgentSeries }) => {
+      if (cancelled) { return; }
       if (chart) { chart.destroy(); }
       currentChart = requestCountByAgentSeries(node, fileSeries);
       setChart(currentChart);
       setHiddenDatasets(new Set());
     });
-    return () => { if (currentChart) { currentChart.destroy(); } };
+    return () => { cancelled = true; if (currentChart) { currentChart.destroy(); } };
   }, [fileSeries]);
 
   const toggleDataset = (index: number) => {

--- a/guide/results-viewer-react/src/components/TestResults/model.ts
+++ b/guide/results-viewer-react/src/components/TestResults/model.ts
@@ -239,7 +239,7 @@ function asBucketEntry (b: unknown): BucketEntry | Error {
   }
   if (!Array.isArray(b[1])) {
     return new Error(
-      `expected second value in bucket entry array to be an array bug got: ${JSON.stringify(
+      `expected second value in bucket entry array to be an array but got: ${JSON.stringify(
         b[1]
       )}`
     );


### PR DESCRIPTION
## Summary

Fixes WASM histogram leaks, use-after-free races, and stale merge/clear state in the TestResults viewer, surfaced by review feedback on the merge-results-view work.

## Reasoned Changes

<details>
<summary><b>Merge-load safety: pre-fetch cloning and overlap detection</b></summary>

**What:** `onMergeLoad` now clones the base `resultsData` before the async fetch loop and calls a new `detectOverlap` check (with a `window.confirm` fallback) before merging.
**Why:** The problem, per commit subjects, was a WASM use-after-free: `state.resultsData` could be freed by a concurrent reload/clear while `onMergeLoad`'s `await` loop was still fetching other agents' files. The design choice was to clone the base entries synchronously up front via the new `cloneParsedEntries` helper and add `detectOverlap` so unrelated (non-concurrent) test runs aren't silently merged. This trades a native, unstylable `confirm()` prompt and an extra full clone of `resultsData` (memory/CPU cost) for correctness against the race — no alternative (e.g., a custom modal or lock) was implemented.

</details>
<details>
<summary><b>Merge/clear state: stale minMaxTime and summaryData</b></summary>

**What:** `onMergeLoad` and `onClearMerge` now recompute and free `minMaxTime`/`summaryData` (via `minMaxTime()` and `getSummaryData()`) instead of leaving them pointing at pre-merge data.
**Why:** The bug, per the commit subject, was that merging or clearing left `minMaxTime` and `summaryData` stale (and leaked their WASM histograms) because only `mergedData`/`mergedAgentTimeSeries`/`mergedTestIds` were updated previously. The fix mirrors the existing `updateResults`/`onResultsFileChange` pattern elsewhere in the same file — free old histograms via `freeHistograms`, then recompute — rather than inventing a new pattern. This keeps the summary panel and time range display consistent with whatever `displayData` (merged vs. base) is currently shown, at the cost of an extra histogram-merge pass on every merge/clear action.

</details>
<details>
<summary><b>Async chart-import race guards and WASM cleanup</b></summary>

**What:** `OverviewChart`, `HostChart`, `AgentChart`, and the three `TestResultsCompare` chart effects now track a `cancelled` flag and check `node.isConnected` before calling `setChart`, and grouped/cloned histogram data is freed via `.finally()` rather than inline after `setOverviewChart`.
**Why:** The problem was a race between the dynamic `import("./charts")` (which resolves asynchronously) and component unmount/re-render, which could set state on a stale node or skip freeing cloned histograms if the promise rejected. The design choice was a standard cancellation-flag pattern plus moving the free call into `.finally()` so cleanup always runs regardless of the promise's outcome. This is a minimal, localized fix rather than introducing a shared async-effect abstraction, accepting some code duplication across the six similar effects.

</details>
<details>
<summary><b>Misc: error-message typo</b></summary>

**What:** Fixed a duplicated typo ("array bug got" → "array but got") identically in `controller/components/TestResults/model.ts` and `guide/results-viewer-react/src/components/TestResults/model.ts`.
**Why:** This is a copy-pasted error string that exists in two near-duplicate `model.ts` files, so the fix was applied to both to keep them in sync. No design trade-off applies here — it is a pure typo correction.

</details>
<details>
<summary><b>Copilot feedback: JSDoc placement, non-blocking auto-merge, and clone test coverage</b></summary>

**What:** Moved `cloneParsedEntries` above the `mergeResults` JSDoc so the doc stays attached to the right function, added a `userInitiated` flag to `onMergeLoad` that skips the `window.confirm()` overlap gate on the auto-merge path, and added `merge.spec.ts` tests proving cloned `DataPoint`s (histogram, statusCounts, testErrors) are independent of their source.
**Why:** These directly resolve the three comments from Copilot's automated review on this PR. For the confirm dialog specifically, the fix was confirmed with the reviewer: a shared merge-results link should merge non-overlapping runs anyway rather than blocking on a native dialog or silently no-op'ing — trading a small correctness/awareness gap on the auto-load path for uninterrupted headless/link-driven navigation.

</details>

## Risk Assessment

Risk concentrates in the merge/clear state recompute and the auto-merge path in `controller/components/TestResults/index.tsx` — the auto-merge path now silently combines non-overlapping test runs with no test coverage exercising it, so a reviewer would first ask what happens when this fires unattended or concurrently.

### Highest-Risk Areas
1. **controller/components/TestResults/index.tsx:1249, 1367** — `onMergeLoad`'s auto-merge path now passes `userInitiated=false` and skips `detectOverlap` entirely, so a shared merge-results link silently merges non-overlapping agent runs with zero user feedback (no confirm, no warning) — this closes the unprompted-dialog bug Copilot flagged, but trades it for a correctness/awareness gap on that same path, and neither the skip nor the silent-merge behavior has test coverage.
2. **controller/components/TestResults/index.tsx:1249-1310** — `onMergeLoad` reads `state.resultsData` via a `useCallback` closure gated only by `[state.resultsData, testData.testId]`; if the user double-clicks "merge" or triggers `onMergeLoad` twice in quick succession before the first `setState` commits, both invocations will call `freeParsedEntries(old.mergedData)` and `freeHistograms(undefined, old.summaryData, ...)` against a stale `old`, plausibly double-freeing the same WASM histogram objects (the `try/catch` in `freeParsedEntries`/`freeHistograms` swallows the error, masking rather than preventing the underlying double-free).
3. **controller/components/TestResults/merge.ts:8-27 (detectOverlap)** — `detectOverlap` only compares `resultsArray[0]`'s bucket timestamps against every other array, not every pair; three-or-more-file merges where file 2 and file 3 overlap with each other but neither overlaps file 1 will still return `false` (blocking a legitimate merge with a confirm prompt) or, conversely, a merge where file 1 coincidentally shares one bucket with an unrelated file 2 will pass overlap detection despite the files being from unrelated runs.
4. **controller/components/TestResults/index.tsx:596-604, 655-661, 700-719** — the `cancelled`/`node.isConnected` guard prevents `setOverviewChart`/`setHostChart`/`setAgentChart` from firing on a stale node, but if `mergeEndpoints` or `displayData` flips twice within one dynamic-import round trip, the earlier effect's `.finally(() => freeGroupedHistograms(...))` still runs and frees histograms that the newer effect's `groupAndMergeByLabel` call may already be referencing via shared underlying `DataPoint` objects, risking a use-after-free in the chart the user is currently viewing.

## Review Hotspots

1. **controller/components/TestResults/index.tsx** — touched by all three "feedback:" commits (`db6b18a`, `0303afd`, `77af5b3`), indicating the WASM lifecycle/race fixes and the resulting Copilot review comments both concentrated repeatedly on this one file.
2. **controller/components/TestResults/index.tsx:1249-1320 (onMergeLoad/onClearMerge)** — high conditional/state-branching density (overlap gate, per-file free loops, functional `setState` with three separate recomputations) concentrated in a single pair of callbacks; still no test exercising `onMergeLoad`/`onClearMerge` directly, even though the underlying `cloneParsedEntries`/`detectOverlap` helpers are now covered.

## Testing

- Lint passed clean on all changed files, including this round's `index.tsx`, `merge.ts`, and `merge.spec.ts` changes.
- `npx tsc --noEmit` passed clean on the controller workspace.
- Added `merge.spec.ts` tests for `cloneParsedEntries` proving cloned `DataPoint`s (histogram, statusCounts, testErrors) are independent references and that mutating/freeing a clone doesn't affect its source. Full suite: 16/16 passing.
- **Known gap:** `onMergeLoad`/`onClearMerge` themselves (the double-invocation double-free risk and the now-silent auto-merge path) remain untested at the component level, and `detectOverlap`'s pairwise-comparison gap (Risk Assessment item 3) is unchanged; consider unit tests for `detectOverlap` (pairwise, not just against file 0) and a guard against concurrent `onMergeLoad` calls before merging further.

## Checklist

- [x] Code follows project style guidelines (lint clean)
- [x] Tests added/updated and passing — added `cloneParsedEntries` independence tests in `merge.spec.ts`; `onMergeLoad`/`onClearMerge` component-level coverage still open (see Testing gap above)
- [x] Documentation updated if needed
- [x] No breaking changes
- [x] Reviewed my own code for obvious issues